### PR TITLE
DSDEEPB-465: first pass at Google sign-in

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
@@ -1,6 +1,8 @@
 (ns org.broadinstitute.firecloud-ui.main
   (:require
    [dmohs.react :as react]
+   [org.broadinstitute.firecloud-ui.session :as session]
+   [org.broadinstitute.firecloud-ui.utils :as utils]
    ))
 
 (defn footer []
@@ -9,14 +11,56 @@
         yeartext (if (= startyear thisyear) (str startyear) (str startyear "-" thisyear))]
     [:div {:style {:padding-top "1em" :font-size 12}} (str "\u00A9 " yeartext " Broad Institute")]))
 
-(def App
+;; Content to display when logged in via Google
+(def LoggedIn
   (react/create-class
    {:render
     (fn []
+      [:div {:style {:padding "50px 25px"}}
+        ;; Leave the Google button on the page to avoid possible errors. TODO: figure out a better way to avoid the errors.
+        [:div {:className "g-signin2" :data-onsuccess "onSignIn" :style {:display "none"}}]
+        [:img {:src "http://www.textfiles.com/underconstruction/CoColosseumHoop5020underconstruction_blk.gif"}]
+        [:br]
+        [:img {:src "http://38.media.tumblr.com/319155ba5ef3d875466b9c07f18b0b8d/tumblr_mpsygdabiG1qzxh6go1_250.gif"}]
+        [:br]
+        [:div {:style {:fontSize "70%"}}
+          [:span {:style {:fontWeight "bold" :marginRight "1ex"}}
+           (-> (session/get-current-user)
+             (utils/call-external-object-method :getBasicProfile)
+             (utils/call-external-object-method :getName))]
+          [:a {:href "javascript:;" :onClick (fn [e] (session/log-out))} "Log-Out"]]
+       ])}))
+
+;; Content to display when logged out
+(def LoggedOut
+  (react/create-class
+   {:render
+    (fn []
+      [:div {:style {:padding "50px 25px"}}
+        [:div {:className "g-signin2" :data-onsuccess "onSignIn" :data-theme "dark"}]])}))
+
+(def App
+  (react/create-class
+   {:handleSignIn ; called from index.html on successful Google sign-in
+        (fn [{:keys [state]} google-user]
+          (session/set-current-user google-user)
+          (swap! state assoc :is-logged-in? true))
+    :render
+    (fn [{:keys [state]}]
       [:div {:style {:padding "1em"}}
         [:div {} [:img {:src "broad_logo.png" :style {:height 36}}]]
-        [:div {:style {:padding-top "1em"}} "Hello World!"]
-        (footer)])}))
+
+        (cond
+          (:is-logged-in? @state) [LoggedIn]
+          :else [LoggedOut]
+        )
+
+        (footer)])
+    :component-did-mount
+    (fn [{:keys [state]}]
+      (session/on-log-out (fn [] (swap! state assoc :is-logged-in? false))))
+    }))
 
 (defn ^:export render [element]
   (react/render (react/create-element App) element))
+

--- a/src/cljs/org/broadinstitute/firecloud_ui/session.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/session.cljs
@@ -1,0 +1,32 @@
+(ns org.broadinstitute.firecloud-ui.session
+  (:require [clojure.string]
+            [dmohs.react :as react]
+            [org.broadinstitute.firecloud-ui.utils :as utils]))
+
+
+(defonce current-user (atom nil))
+
+
+(defonce on-log-out-atom (atom nil))
+
+
+(defn get-current-user []
+  @current-user)
+
+
+(defn set-current-user [user]
+  (reset! current-user user))
+
+
+(defn log-out []
+  (-> js/gapi
+    (aget "auth2")
+    (utils/call-external-object-method :getAuthInstance)
+    (utils/call-external-object-method :signOut)
+    (utils/call-external-object-method
+      :then (fn [] (reset! current-user nil) (@on-log-out-atom) (.reload (.-location js/window))))))
+
+
+(defn on-log-out [callback]
+  (reset! on-log-out-atom callback)
+  )

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -1,0 +1,7 @@
+(ns org.broadinstitute.firecloud-ui.utils)
+
+
+(defn call-external-object-method [obj method-name & args]
+  "Call an external object's method by name, since a normal call will get renamed during
+   advanced compilation and cause an error."
+  (apply (.bind (aget obj (name method-name)) obj) args))

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -3,6 +3,8 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-type" content="text/html;charset=utf-8">
     <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="google-signin-scope" content="profile email">
+    <meta name="google-signin-client_id" content="806222273987-2ntvt4hnfsikqmhhc18l64vheh4cj34q.apps.googleusercontent.com">
     <title>FireCloud | Broad Institute</title>
     <style>
       body {
@@ -10,6 +12,7 @@
         margin: 0;
       }
     </style>
+    <script src="https://apis.google.com/js/platform.js" async defer></script>
     <script src="../../target/cljsbuild-compiler-0/goog/base.js"></script>
   </head>
   <body>
@@ -18,6 +21,9 @@
     <script>goog.require('org.broadinstitute.firecloud_ui.main');</script>
     <script>
       var app = org.broadinstitute.firecloud_ui.main.render(document.getElementById('contentRoot'));
+      function onSignIn(googleUser) {
+        app.handleSignIn(googleUser);
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
This PR does not fully satisfy DSDEEPB-465, but I'm hoping to build this incrementally - looking for a review/merge on code so far, and I'll add the remainder of the functionality in a future PR.

This PR includes:
* contextually displaying either a sign-in button (when logged out) or some sample content including your name (when logged in)
* Google auth against the broad-dsde-dev project

I've done this using David Mohs' cloud-pilot prototype as a starting point, and I've included his session and utils classes as support.

This PR does NOT include:
* any integration with OpenAM. This is Google auth only, which won't help in getting an OpenAM token
* the privacy statement/warning requested by NCI/NIH
* an under construction animated gif of construction guy with candy corn hat. I'm still trying to find one of those.