### PR TITLE
do the build IN the docker build. use local-serv, since this is being…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM httpd:2.4
-#Once lein builds site/content, copy target/ over to be served up
-#RUN mkdir /usr/local/apache2/htdocs/target
-#RUN mkdir /usr/local/apache2/htdocs/src
-COPY target/ /usr/local/apache2/htdocs/
-COPY src/static/assets/ /usr/local/apache2/htdocs/assets/
-#COPY src/ /usr/local/apache2/htdocs/src
+FROM centos:7
+
+RUN curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > /usr/bin/lein
+RUN chmod 755 /usr/bin/lein
+RUN yum -y install java-1.8.0-openjdk php-cli && yum clean all
+
+EXPOSE 8000
+
+COPY project.clj /usr/firecloud-ui/project.clj
+COPY src  /usr/firecloud-ui/src
+COPY script /usr/firecloud-ui/script
+
+WORKDIR /usr/firecloud-ui
+RUN ./script/dev/build-once.sh
+RUN lein test
+
+CMD ./script/dev/serve-locally.sh
+


### PR DESCRIPTION
… fronted now

This way the docker build can match the development build, basically 1:1. So as it changes, so long as the docker file is kept up-to-date, jenkins just has the build the container, not the app+container.   