### PR TITLE
Un-mock methods list request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 FireCloud user interface for web browsers.
 
+https://firecloud-ci.broadinstitute.org/
+
 ## Getting Started
 
 We use the Leiningen build tool. To install, follow the installation instructions on the [Leiningen web site](http://leiningen.org/).
@@ -37,7 +39,12 @@ Start a static file server:
 ./script/dev/serve-locally.sh
 ```
 
-This will serve files at http://localhost:8000/.
+This will serve files at http://localhost:8000/. However, Google Sign-In expects an origin of
+http://local.broadinstitute.org:8000/. To make your local instance available at this URL, add the following to
+/etc/hosts:
+```
+127.0.0.1 local.broadinstitute.org
+```
 
 ## Testing
 


### PR DESCRIPTION
Hooks the methods list to a live server call. If this approach works, it can be used for other calls going forward.

Task: https://broadinstitute.atlassian.net/browse/DSDEEPB-654