### PR TITLE
Adding keyboard control to the Create Workspace dialog

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -34,16 +34,19 @@
 (react/defc Button
   {:get-default-props
    (fn []
-     {:color :blue})
+     {:color (:button-blue colors)})
    :render
    (fn [{:keys [props]}]
-     [:span {:style {:display "inline-block"
-                     :backgroundColor (case (:color props)
-                                        (:button-blue colors))
-                     :color "white" :fontWeight 500
-                     :borderRadius 2 :padding "0.7em 1em"
-                     :cursor "pointer"}
-             :onClick (fn [e] ((:onClick props) e))}
+     [:a {:style {:display "inline-block"
+                  :backgroundColor (:color props)
+                  :color "white" :fontWeight 500
+                  :borderRadius 2 :padding "0.7em 1em"
+                  :textDecoration "none"}
+          :href "javascript:;"
+          :onClick (fn [e] ((:onClick props) e))
+          :onKeyDown (fn [e]
+                       (let [k (.-keyCode e)]
+                         (when (or (= 32 k) (= 13 k)) ((:onClick props) e))))}
       (:text props)
       (when (= (:style props) :add)
         [:span {:style {:display "inline-block" :height "1em" :width "1em" :marginLeft "1em"

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces.cljs
@@ -153,36 +153,42 @@
    :width "100%" :fontSize "88%"})
 
 (defn- render-overlay [state refs]
-  [:div {:style (modal-background state)}
-   [:div {:style modal-content}
-    [:div {:style {:backgroundColor "#fff"
-                   :borderBottom "1px solid #e3e3e3"
-                   :padding "20px 48px 18px"
-                   :fontSize "137%" :fontWeight 400 :lineHeight 1}}
-     "Create New Workspace"]
-    [:div {:style {:padding "22px 48px 40px" :boxSizing "inherit"}}
-     [:div {:style form-label} "Name Your Workspace"]
-     [:input {:type "text" :style new-ws-input-style :ref "wsName"}]
-     [:div {:style form-label} "Workspace Description"]
-     [:textarea {:style new-ws-input-style :rows 10 :cols 30 :ref "wsDesc"}]
-     [:div {:style form-label} "Research Purpose"]
-     [:select {:style select} [:option {} "Option 1"] [:option {} "Option 2"] [:option {} "Option 3"]]
-     [:div {:style form-label} "Billing Contact"]
-     [:select {:style select} [:option {} "Option 1"] [:option {} "Option 2"] [:option {} "Option 3"]]
-     [:div {:style form-label} "Share With (optional)"]
-     [:input {:type "text" :style new-ws-input-style :ref "shareWith"}]
-     [:em {:style {:fontSize "69%"}} "Separate multiple emails with commas"]
-     (let [clear-overlay (fn []
-                           (set! (.-value (.getDOMNode (@refs "wsName"))) "")
-                           (set! (.-value (.getDOMNode (@refs "wsDesc"))) "")
-                           (set! (.-value (.getDOMNode (@refs "shareWith"))) "")
-                           (swap! state assoc :overlay-shown? false))]
+  (let [clear-overlay (fn []
+                        (set! (.-value (.getDOMNode (@refs "wsName"))) "")
+                        (set! (.-value (.getDOMNode (@refs "wsDesc"))) "")
+                        (set! (.-value (.getDOMNode (@refs "shareWith"))) "")
+                        (swap! state assoc :overlay-shown? false))]
+    [:div {:style (modal-background state)
+           :onKeyDown (fn [e] (when (= 27 (.-keyCode e)) (clear-overlay)))}
+     [:div {:style modal-content}
+      [:div {:style {:backgroundColor "#fff"
+                     :borderBottom "1px solid #e3e3e3"
+                     :padding "20px 48px 18px"
+                     :fontSize "137%" :fontWeight 400 :lineHeight 1}}
+       "Create New Workspace"]
+      [:div {:style {:padding "22px 48px 40px" :boxSizing "inherit"}}
+       [:div {:style form-label} "Name Your Workspace"]
+       [:input {:type "text" :style new-ws-input-style :ref "wsName"}]
+       [:div {:style form-label} "Workspace Description"]
+       [:textarea {:style new-ws-input-style :rows 10 :cols 30 :ref "wsDesc"}]
+       [:div {:style form-label} "Research Purpose"]
+       [:select {:style select} [:option {} "Option 1"] [:option {} "Option 2"] [:option {} "Option 3"]]
+       [:div {:style form-label} "Billing Contact"]
+       [:select {:style select} [:option {} "Option 1"] [:option {} "Option 2"] [:option {} "Option 3"]]
+       [:div {:style form-label} "Share With (optional)"]
+       [:input {:type "text" :style new-ws-input-style :ref "shareWith"}]
+       [:em {:style {:fontSize "69%"}} "Separate multiple emails with commas"]
        [:div {:style {:marginTop 40 :textAlign "center"}}
-        [:a {:style {:marginRight 27 :paddingTop "0.52em"
-                     :display "inline-block" :cursor "pointer"
-                     :fontSize "106%" :fontWeight 500
+        [:a {:style {:marginRight 27 :marginTop 2 :padding "0.5em"
+                     :display "inline-block"
+                     :fontSize "106%" :fontWeight 500 :textDecoration "none"
                      :verticalAlign "top"
-                     :color (:button-blue common/colors)} :onClick clear-overlay}
+                     :color (:button-blue common/colors)}
+             :href "javascript:;"
+             :onClick clear-overlay
+             :onKeyDown (fn [e]
+                          (let [k (.-keyCode e)]
+                            (when (or (= 32 k) (= 13 k)) (clear-overlay))))}
          "Cancel"]
         [common/Button {:text "Create Workspace"
                         :onClick
@@ -202,7 +208,7 @@
                                                 :name n
                                                 :createdBy n
                                                 :createdDate (.toISOString (js/Date.))})
-                                :delay-ms (rand-int 2000)}})))}]])]]])
+                                :delay-ms (rand-int 2000)}})))}]]]]]))
 
 
 (defn- create-mock-workspaces []
@@ -251,4 +257,4 @@
                        (swap! state assoc :workspaces-loaded? true :workspaces workspaces))
                      (swap! state assoc :error-message (.-statusText xhr))))
         :canned-response {:responseText (utils/->json-string (create-mock-workspaces))
-                          :delay-ms (rand-int 2000)}}))})
+                          :status 200 :delay-ms (rand-int 2000)}}))})


### PR DESCRIPTION
* Made common/Button an <a> instead of a <div> with an onClick.  This automatically makes it part of the focus cycle, including styling to highlight when focused.
* Added onKeyDown functions to make common/Button and the Create Workspace 'cancel' button respond to [space] or [enter] when focused.  TODO: a utility function to reduce repetition
* ESC key functions the same as 'cancel'.  However, the focus must be on one of the dialog's components for this to work; another TODO is to focus the workspace name field when the dialog is shown, which would reduce this problem.