### PR TITLE
view entities of a single type in the workspace data tab (temp soln)

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces.cljs
@@ -121,6 +121,33 @@
                           "Me"])
                     filtered-workspaces)})])]))})
 
+(react/defc EntitiesList
+  {:render
+   (fn [{:keys [props]}]
+     [:div {:style {:padding "0 4em"}}
+      (if (zero? (count (:entities props)))
+        [:div {:style {:textAlign "center" :backgroundColor (:background-gray style/colors)
+                       :padding "1em 0" :borderRadius 8}}
+         "No entities to display."]
+        [table/Table
+         (let [cell-style {:flexBasis "8ex" :flexGrow 1 :whiteSpace "nowrap" :overflow "hidden"
+                           :borderLeft (str "1px solid " (:line-gray style/colors))}
+               header-label (fn [text & [padding]]
+                              [:span {:style {:paddingLeft (or padding "1em")}}
+                               [:span {:style {:fontSize "90%"}} text]])]
+           {:columns [{:label (header-label "Entity Type")
+                       :style (merge cell-style {:borderLeft "none"})}
+                      {:label (header-label "Entity Name")
+                       :style cell-style
+                       :header-style {:borderLeft "none"}}
+                      {:label (header-label "Attributes")
+                       :style (merge cell-style {:flexBasis "30ex"})
+                       :header-style {:borderLeft "none"}}]
+            :data (map (fn [m]
+                         [(m "entityType") ;;properly map to entities after
+                          (m "name")
+                          (m "attributes")])
+                       (:entities props))})])])})
 
 (react/defc FilterButtons
   (let [Button
@@ -153,6 +180,43 @@
           [Button {:text (build-text "Exception" :exception) :state state :filter :exception}]
           [:div {:style {:clear "both"}}]]))}))
 
+(react/defc EntityFilterButtons
+            (let [Button
+                  (react/create-class
+                    {:render
+                     (fn [{:keys [props]}]
+                       [:div {:style {:float "left"
+                                      :backgroundColor (if (:active? props)
+                                                         (:button-blue style/colors)
+                                                         (:background-gray style/colors))
+                                      :color (when (:active? props) "white")
+                                      :marginLeft "1em" :padding "1ex" :width "16ex"
+                                      :border (str "1px solid " (:line-gray style/colors))
+                                      :borderRadius "2em"
+                                      :cursor "pointer"}}
+                        (:text props)])})]
+              {:render
+               (fn []
+                 [:div {:style {:display "inline-block" :marginLeft "-1em"}}
+                  [Button {:text "sample" :active? true}]
+                  [Button {:text "aliquot"}]
+                  [Button {:text "all"}]
+                  [:div {:style {:clear "both"}}]])}))
+
+(defn- contains-text [text fields]
+  (fn [entity]
+    (some #(not= -1 (.indexOf (entity %) text)) fields)))
+
+(defn- filter-entities [entities fields text]
+  (filter (contains-text text fields) entities))
+
+(defn- create-mock-entities []
+  (map
+    (fn [i]
+      {:entityType (rand-nth ["sample"])
+       :name (str "entity" (inc i))
+       :attributes (str "entity" (inc i) " has no attributes")})
+    (range (rand-int 20))))
 
 (defn- modal-background [state]
   {:backgroundColor "rgba(82, 129, 197, 0.4)"
@@ -282,12 +346,17 @@
     (create-paragraph [:em {} "Billing account not available yet"])]
    [:div {:style {:clear "both"}}]])
 
-(defn- render-selected-workspace [workspace]
+(defn- render-workspace-data [entities]
+  [:div {:style {:padding "2em 0" :textAlign "center"}}
+   [EntityFilterButtons]
+  [:div {:style {:padding "2em 0"}} [EntitiesList {:entities entities}]]])
+
+(defn- render-selected-workspace [workspace entities]
   [:div {}
    (if workspace
      [comps/TabBar {:key "selected"
                     :items [{:text "Summary" :component (render-workspace-summary workspace)}
-                            {:text "Data"}
+                            {:text "Data" :component (render-workspace-data entities)}
                             {:text "Methods"}
                             {:text "Monitor"}
                             {:text "Files"}]}]
@@ -358,7 +427,7 @@
             :onClick #(swap! state assoc :overlay-shown? true)}]]
          [:span {:style {:fontSize "180%"}} (if selected-ws-name selected-ws-name "Workspaces")]]
         (cond
-          selected-ws-name (render-selected-workspace selected-ws)
+          selected-ws-name (render-selected-workspace selected-ws (:entities @state))
           (:workspaces-loaded? @state) (render-workspaces-list state nav-context)
           (:error @state) (style/create-server-error-message (get-in @state [:error :message]))
           :else [comps/Spinner {:text "Loading workspaces..."}])]))
@@ -376,4 +445,15 @@
                      (swap! state assoc
                             :error {:message (.-statusText xhr)})))
         :canned-response {:responseText (utils/->json-string (create-mock-workspaces))
-                          :status 200 :delay-ms (rand-int 2000)}}))})
+                          :status 200 :delay-ms (rand-int 2000)}})
+     (utils/ajax-orch
+       "/workspaces/broad-dsde-dev/testws/entities/sample"
+       {:on-done (fn [{:keys [success? xhr]}]
+                   (if success?
+                     (let [entities (utils/parse-json-string (.-responseText xhr))]
+                       (swap! state assoc :entities-loaded? true
+                              :entities entities))
+                     (swap! state assoc :error-message (.-statusText xhr))))
+        :canned-response {:responseText (utils/->json-string (create-mock-entities))
+                          :status 200
+                          :delay-ms (rand-int 2000)}}))})


### PR DESCRIPTION
this is a temporary solution to fulfill [DSDEEPB-746](https://broadinstitute.atlassian.net/browse/DSDEEPB-746). in the future, the ajax call will be done in an area where it can be reloaded based on which workspace is selected and which entity type is selected. this solution solely demonstrates the ability to pull in workspace entities from rawls and display those entities in a formatted table