### PR TITLE
1) Propagation of workspace-information to import MC screen ; 2) GUI mods for actual import

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
@@ -66,18 +66,18 @@
                                                      (:header-darkgray style/colors)}}
                                         children])
                  cell (fn [children] [:span {:style {:paddingLeft 16}} children])]
-             {:columns [{:header-component [:div {:style {:padding "13px 0 12px 12px"
-                                                          :backgroundColor (:header-darkgray style/colors)}}
-                                            [:input {:type "checkbox" :ref "imcallcheck"}]]
-                         :starting-width 42 :resizable? false
+             {:columns [{:header-component (header "Name") :starting-width 200
                          :cell-renderer (fn [row-num conf]
-                                          [:div {:style {:paddingLeft 12}}
-                                           [:input {:type "checkbox" :ref (str "imc_" row-num)}]])}
-                        {:header-component (header "Name") :starting-width 200
-                         :cell-renderer (fn [row-num conf]
-                                          (cell [:a {:href "javascript:;"
-                                                     :style {:color (:button-blue style/colors)
-                                                             :textDecoration "none"}} (conf "name")]))}
+                                          (cell [:a {:onClick
+                                                     (fn [] (js/alert
+                                                              (str "TODO : process/prompt for "
+                                                                "import of this method configuration "
+                                                                conf " into the workspace →"
+                                                                (get props :workspace) )))
+                                                     :href "javascript:;"
+                                                     :style {:color
+                                                              (:button-blue style/colors) :textDecoration "none"}}
+                                                 (conf "name")]))}
                         {:header-component (header "Namespace") :starting-width 200
                          :cell-renderer (fn [row-num conf] (cell (conf "namespace")))}
                         {:header-component (header "Type") :starting-width 100
@@ -133,7 +133,7 @@
    :width "90%"})
 
 
-(defn render-import-overlay [state]
+(defn render-import-overlay [state  workspace ]
   (let [clear-import-overlay #(swap! state assoc :import-overlay-shown? false)]
     (when (:import-overlay-shown? @state)
       [:div {:style modal-import-background
@@ -147,9 +147,6 @@
         [:div {:style {:backgroundColor "#fff"
                        :borderBottom (str "1px solid " (:line-gray style/colors))
                        :padding "20px 48px 18px"}}
-         [:div {:style {:fontSize 24 :align "center" :textAlign "center" :paddingBottom "0.5em"}}
-          "Select Method Configurations For Import"]
-         [ImportWorkspaceMethodsConfigurationsList]
-         [:div {:style {:paddingTop "0.5em"}}
-          [comps/Button {:style :add :text "Add selected to workspace"
-                         :onClick #(swap! state assoc :import-overlay-shown? false)}]]]]])))
+         [:div {:style {:fontSize 24 :align "center" :textAlign "center" :paddingBottom "0.5em"}} "Select A Method Configuration For Import"]
+         [ImportWorkspaceMethodsConfigurationsList {:workspace workspace}]
+         [:div {:style {:paddingTop "0.5em"}}]]]])))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/workspace_method_confs.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/workspace_method_confs.cljs
@@ -39,7 +39,7 @@
   {:render
    (fn [{:keys [props refs state]}]
      [:div {}
-      (importmc/render-import-overlay state)
+      (importmc/render-import-overlay state (:workspace props) )
       [:div {:style {:float "right" :padding "0 2em 1em 0"}}
        [comps/Button {:text "Import Configurations..."
                       :onClick #(swap! state assoc :import-overlay-shown? true)}]]
@@ -99,12 +99,13 @@
 
 (react/defc WorkspaceMethodConfigurations
   {:render
-   (fn [{:keys [state]}]
+   (fn [{:keys [state props]}]
      [:div {:style {:padding "1em 0"}}
       [:div {}
        (cond
          (:selected-method-config @state) [MethodConfigEditor {:config (:selected-method-config @state)}]
-         (:method-confs-loaded? @state) [WorkspaceMethodsConfigurationsList {:method-confs (:method-confs @state)
+         (:method-confs-loaded? @state) [WorkspaceMethodsConfigurationsList {:workspace (:workspace props)
+                                                                             :method-confs (:method-confs @state)
                                                                              :parent-state state}]
          (:error-message @state) [:div {:style {:color "red"}}
                                   "FireCloud service returned error: " (:error-message @state)]


### PR DESCRIPTION
Removed checkboxes from import MC window and replaced them with gear buttons.

These gear buttons ar intended to import a single/given/unique MC at a time
Removed the "Import Selected ..." big button.  The only way to leave the screen is through the X.

Propagate workspace information to the MC import screen

Minor text tweak for TODO alert.
The import button tells us a TODO