### PR TITLE
Fix hot-reloading after uncaught exception.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies
   [
    ;; React library and cljs bindings for React.
-   [dmohs/react "0.2.5"]
+   [dmohs/react "0.2.6"]
    [org.clojure/clojure "1.6.0"]
    [org.clojure/clojurescript "0.0-3211"]
    [inflections "0.9.14"]

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -34,6 +34,7 @@
 
 
 (def use-live-data? true)
+(when-not use-live-data? (assert goog.DEBUG "Mock data in use but DEBUG is false."))
 
 
 (defn ajax [arg-map]
@@ -43,8 +44,7 @@
         headers (:headers arg-map)
         data (:data arg-map)
         with-credentials? (:with-credentials? arg-map)
-        canned-response-params (when (and goog.DEBUG (not use-live-data?))
-                                 (:canned-response arg-map))]
+        canned-response-params (when-not use-live-data? (:canned-response arg-map))]
     (assert url (str "Missing url parameter: " arg-map))
     (assert on-done (str "Missing on-done callback: " arg-map))
     (let [xhr (if-not canned-response-params


### PR DESCRIPTION
This is fixed in v0.2.6 of the wrapper, so just bumping the version.