### PR TITLE
change the URL path to match the orchestration endpoint path

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
@@ -177,9 +177,7 @@
         :else [comps/Spinner {:text "Loading configurations for import..."}])])
    :component-did-mount
    (fn [{:keys [state props]}]
-     (utils/ajax-orch
-       (str "/workspaces/" (:selected-workspace-namespace props)
-         "/" (:selected-workspace props) "/methodconfigs")
+     (utils/ajax-orch (str "/configurations")
        {:on-done (fn [{:keys [success? xhr]}]
                    (if success?
                      (do


### PR DESCRIPTION
indicated in src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala