### PR TITLE
Load workspace details on summary page

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/workspace_data.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/workspace_data.cljs
@@ -73,5 +73,5 @@
                           :status 200
                           :delay-ms (rand-int 2000)}}))})
 
-(defn render-workspace-data [workspace entities]
-  [WorkspaceData {:workspace workspace :entities entities}])
+(defn render-workspace-data [workspace]
+  [WorkspaceData {:workspace workspace}])

--- a/src/cljs/org/broadinstitute/firecloud_ui/paths.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/paths.cljs
@@ -2,6 +2,9 @@
 
 (defn list-workspaces-path [] "/workspaces")
 
+(defn workspace-details-path [workspace-id]
+  (str "/workspaces/" (:namespace workspace-id) "/" (:name workspace-id)))
+
 (defn create-workspace-path [] "/workspaces")
 
 (defn list-method-configs-path [workspace]


### PR DESCRIPTION
- namespace input on workspace creation dialog
- only load workspace list when viewing it

Note: This depends on https://github.com/broadinstitute/firecloud-orchestration/pull/53 and should not be merged until that PR is merged.