### PR TITLE
Added filterer to tables

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
@@ -46,25 +46,15 @@
 
 (react/defc Page
   {:render
-   (fn [{:keys [state refs]}]
+   (fn [{:keys [state]}]
      [:div {:style {:padding "1em"}}
       [:h2 {} "Method Repository"]
       [:div {}
        (cond
-         (:methods-loaded? @state) [:div {}
-                                    (let [apply-filter #(swap! state assoc
-                                                          :filter-text
-                                                          (.-value (.getDOMNode (@refs "input"))))]
-                                      [:div {:style {:paddingBottom "1em" :paddingLeft "4em"}}
-                                       (style/create-text-field {:ref "input" :placeholder "Filter"
-                                                                 :onKeyDown (common/create-key-handler
-                                                                              [:enter] apply-filter)})
-                                       [:span {:style {:paddingLeft "1em"}}]
-                                       [comps/Button {:icon :search :onClick apply-filter}]])
-                                    [MethodsList {:methods (filter-methods
-                                                             (:methods @state)
-                                                             ["namespace" "name" "synopsis"]
-                                                             (or (:filter-text @state) ""))}]]
+         (:methods-loaded? @state) [MethodsList {:methods (filter-methods
+                                                            (:methods @state)
+                                                            ["namespace" "name" "synopsis"]
+                                                            (or (:filter-text @state) ""))}]
          (:error @state) (style/create-server-error-message (get-in @state [:error :message]))
          :else [comps/Spinner {:text "Loading methods..."}])]])
    :component-did-mount

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
@@ -128,7 +128,7 @@
         (if (zero? (count (:method-confs @state)))
           (style/create-message-well "There are no method configurations to display for import!")
           [table/Table
-           {:columns [{:header "Name" :starting-width 200
+           {:columns [{:header "Name" :starting-width 200 :filter-by #(% "name")
                        :content-renderer
                        (fn [row-index conf]
                          [:a

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/workspace_method_confs.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/workspace_method_confs.cljs
@@ -54,6 +54,7 @@
         [table/Table
          {:columns
           [{:header "Name" :starting-width 200 :sort-by #(% "name")
+            :filter-by #(% "name")
             :content-renderer
             (fn [row-index config]
               [:a {:href "javascript:;"

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -74,14 +74,17 @@
               :columns
               [{:header [:div {:style {:marginLeft -6}} "Status"] :starting-width 60
                 :content-renderer (fn [row-index data]
-                                    [StatusCell {:data data}])}
+                                    [StatusCell {:data data}])
+                :filter-by :status}
                {:header "Workspace" :starting-width 250
                 :content-renderer (fn [row-index data]
-                                    [WorkspaceCell {:data data}])}
+                                    [WorkspaceCell {:data data}])
+                :filter-by :name}
                {:header "Description" :starting-width 400
                 :content-renderer (fn [row-index data]
                                     [:div {:style {:padding "1.1em 0 0 14px"}}
-                                     "No data available."])}]
+                                     "No data available."])
+                :filter-by :none}]
               :data (map (fn [workspace]
                            [{:status (workspace "status")
                              :onClick #((:onWorkspaceSelected props) workspace)}

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -1,6 +1,6 @@
 (ns org.broadinstitute.firecloud-ui.utils
   (:require
-    [clojure.string :refer [join]]
+    [clojure.string :refer [join lower-case]]
     ))
 
 
@@ -24,6 +24,10 @@
 (defn str-index-of
   ([s what] (.indexOf s what))
   ([s what start-index] (.indexOf s what start-index)))
+
+
+(defn contains-ignore-case [s what]
+  (<= 0 (str-index-of (lower-case s) (lower-case what))))
 
 
 (defn call-external-object-method


### PR DESCRIPTION
Filterer is controlled by `:filterable?` property, defaults to `true`.

Columns filter by string value, or a specified :`filter-by` function taking the column value.  Filtering can be disabled for a column by setting `:filter-by :none`.

Filtering has been added to all tables.  The only changes needed to them was to specify a custom filterer for columns that were not `str`-able.