### PR TITLE
More table futzing

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -252,15 +252,15 @@
        (:data props)
        (filter
          (fn [row]
-           (some identity
-             (map-indexed
-               (fn [i column]
-                 (if-let [f (:filter-by column)]
-                   (if (= f :none)
-                     false
-                     (utils/contains-ignore-case (f (nth row i)) filter-text))
-                   (utils/contains-ignore-case (str (nth row i)) filter-text)))
-               (:columns props))))
+           (utils/matches-filter-text
+             (apply str
+               (map-indexed
+                 (fn [i column]
+                   (if-let [f (:filter-by column)]
+                     (if (= f :none) "" (f (nth row i)))
+                     (str (nth row i))))
+                 (:columns props)))
+             filter-text))
          (:data props))))
    :handle-pagination-change
    (fn [{:keys [this refs]}]

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -1,6 +1,6 @@
 (ns org.broadinstitute.firecloud-ui.utils
   (:require
-    [clojure.string :refer [join lower-case]]
+    [clojure.string :refer [join lower-case split]]
     ))
 
 
@@ -26,8 +26,17 @@
   ([s what start-index] (.indexOf s what start-index)))
 
 
+(defn contains [s what]
+  (<= 0 (str-index-of s what)))
+
+
 (defn contains-ignore-case [s what]
-  (<= 0 (str-index-of (lower-case s) (lower-case what))))
+  (contains (lower-case s) (lower-case what)))
+
+
+(defn matches-filter-text [source filter-text]
+  (let [lc-source (lower-case source)]
+    (every? (fn [word] (contains lc-source word)) (split (lower-case filter-text) #" "))))
 
 
 (defn call-external-object-method

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -36,7 +36,7 @@
 
 (defn matches-filter-text [source filter-text]
   (let [lc-source (lower-case source)]
-    (every? (fn [word] (contains lc-source word)) (split (lower-case filter-text) #" "))))
+    (every? (fn [word] (contains lc-source word)) (split (lower-case filter-text) #"\s+"))))
 
 
 (defn call-external-object-method


### PR DESCRIPTION
Left as separate commits so it's easier to see the changes.

* Fixed the paginator page range to always show (at most) 5 numbers, so next and prev buttons don't move out from under the mouse.
* Changed the column resize cursor
* Double-click a column resizing tab to reset the column to its initial width
* Table filtering now checks if the row contains all of the space-separated words in the search text
* Refactor of header/body cell rendering code