### PR TITLE
first pass at submitting analyses; work in progress

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
@@ -143,93 +143,110 @@
        "Launch Analysis"]])])
 
 (defn- render-launch-overlay [state refs workspace config]
-  [comps/ModalDialog
-   {:show-when (:submitting? @state)
-    :dismiss-self #(swap! state assoc :submitting? false)
-    :width "80%"
-    :content
-    (react/create-element
-      [:div {}
-       [:div {:style {:backgroundColor "#fff"
-                      :borderBottom (str "1px solid " (:line-gray style/colors))
-                      :padding "20px 48px 18px"
-                      :fontSize "137%" :fontWeight 400 :lineHeight 1}}
-        "Select Entity"]
-       [:div {:style {:position "absolute" :top 4 :right 4}}
-        [comps/Button {:icon :x :onClick #(swap! state assoc :submitting? false)}]]
-       [:div {:style {:padding "22px 48px 40px" :backgroundColor (:background-gray style/colors)}}
-        (style/create-form-label "Select Entity Type")
-        (style/create-select
-          {:style {:width "50%" :minWidth 50 :maxWidth 200} :ref "filter"
-           :onChange #(let [value (-> (@refs "filter") .getDOMNode .-value)]
-                       (when-not (= value "Select...")
-                         (utils/call-ajax-orch
-                           (paths/list-all-entities-path workspace value)
-                           {:on-success (fn [{:keys [parsed-response]}]
-                                          (swap! state assoc :entities parsed-response
-                                            :selected-entity (first parsed-response)))
-                            :on-failure (fn [{:keys [status-text]}]
-                                          (utils/rlog "Error: " status-text))
-                            :mock-data [{"entityType" value
-                                         "name" "A mock entity"
-                                         "attributes" {}}]})))}
-          (:entity-types @state))
-        (style/create-form-label "Select Entity")
-        (if (zero? (count (:entities @state)))
-          (style/create-message-well "No entities to display.")
-          [:div {:style {:backgroundColor "#fff" :border (str "1px solid " (:line-gray style/colors))
-                         :padding "1em" :marginBottom "0.5em"}}
-           [table/Table
-            {:columns [{:header "" :starting-width 40 :resizable? false
-                        :content-renderer (fn [row-index data]
-                                            [:input {:type "radio"
-                                                     :checked (identical? data (:selected-entity @state))
-                                                     :onChange #(swap! state assoc :selected-entity data)}])}
-                       {:header "Entity Type" :starting-width 100}
-                       {:header "Entity Name" :starting-width 100}
-                       {:header "Attributes" :starting-width 400}]
-             :data (map (fn [m]
-                          [m
-                           (m "entityType")
-                           (m "name")
-                           (m "attributes")])
-                     (:entities @state))}]])
-        (style/create-form-label "Define Expression")
-        (style/create-text-field {:ref "expressionname" :defaultValue "this"})]
+       [comps/ModalDialog
+        {:show-when (:submitting? @state)
+         :dismiss-self #(swap! state assoc :submitting? false)
+         :width "80%"
+         :content
+         (react/create-element
+           [:div {}
+            [:div {:style {:backgroundColor "#fff"
+                           :borderBottom (str "1px solid " (:line-gray style/colors))
+                           :padding "20px 48px 18px"
+                           :fontSize "137%" :fontWeight 400 :lineHeight 1}}
+             "Select Entity"]
+            [:div {:style {:position "absolute" :top 4 :right 4}}
+             [comps/Button {:icon :x :onClick #(swap! state assoc :submitting? false)}]]
+            [:div {:ref "launchContainer" :style {:padding "22px 48px 40px" :backgroundColor (:background-gray style/colors)}}
+             (style/create-form-label "Select Entity Type")
+             (style/create-select
+               {:style {:width "50%" :minWidth 50 :maxWidth 200} :ref "filter"
+                :onChange #(let [value (-> (@refs "filter") .getDOMNode .-value)]
+                                (when-not (= value "Select...")
+                                          (utils/call-ajax-orch
+                                            (paths/list-all-entities-path workspace value)
+                                            {:on-success (fn [{:keys [parsed-response]}]
+                                                             (swap! state assoc :entities parsed-response
+                                                                    :selected-entity (first parsed-response)))
+                                             :on-failure (fn [{:keys [status-text]}]
+                                                             (utils/rlog "Error: " status-text))
+                                             :mock-data [{"entityType" value
+                                                          "name" "A mock entity"
+                                                          "attributes" {}}]})))}
+               (:entity-types @state))
+             (style/create-form-label "Select Entity")
+             (if (zero? (count (:entities @state)))
+               (style/create-message-well "No entities to display.")
+               [:div {:style {:backgroundColor "#fff" :border (str "1px solid " (:line-gray style/colors))
+                              :padding "1em" :marginBottom "0.5em"}}
+                [table/Table
+                 {:columns [{:header "" :starting-width 40 :resizable? false
+                             :content-renderer (fn [row-index data]
+                                                   [:input {:type "radio"
+                                                            :checked (identical? data (:selected-entity @state))
+                                                            :onChange #(swap! state assoc :selected-entity data)}])}
+                            {:header "Entity Type" :starting-width 100}
+                            {:header "Entity Name" :starting-width 100}
+                            {:header "Attributes" :starting-width 400}]
+                  :data (map (fn [m]
+                                 [m
+                                  (m "entityType")
+                                  (m "name")
+                                  (m "attributes")])
+                             (:entities @state))}]])
+             (style/create-form-label "Define Expression")
+             (style/create-text-field {:ref "expressionname" :defaultValue "" :placeholder "leave blank for default"})]
+            [:div {:style {:fontSize "106%" :lineHeight 1 :textAlign "center"}}
+             [:div {:style {:padding "0.7em 0" :cursor "pointer"
+                            :backgroundColor (:button-blue style/colors)
+                            :color "#fff" :borderRadius 4
+                            :border (str "1px solid " (:line-gray style/colors))}
 
-       [:div {:style {:fontSize "106%" :lineHeight 1 :textAlign "center"}}
-        [:div {:style   {:padding         "0.7em 0" :cursor "pointer"
-                         :backgroundColor (:button-blue style/colors)
-                         :color "#fff" :borderRadius 4
-                         :border          (str "1px solid " (:line-gray style/colors))}
-
-               ;; TODO: what should we show in the UI after submitting?
-               ;; TODO: if no expression entered, do not send one in the ajax request
-               ;; TODO: disable/enable submit button based on the state of entity selection & expression value
-               ;; TODO: diable submit button after submitting
-               ;; TODO: better canned response
-               :onClick (fn [{:keys []}]
-                            (utils/ajax-orch
-                              (paths/submit-method-path workspace)
-                              {:method :post
-                               :data (utils/->json-string {:methodConfigurationNamespace (config "namespace")
-                                                           :methodConfigurationName      (config "name")
-                                                           :entityType                   ((:selected-entity @state) "entityType")
-                                                           :entityName                   ((:selected-entity @state) "name")
-                                                           :expression                   (-> (@refs "expressionname") .getDOMNode .-value)
-                                                           })
-                               :headers {"Content-Type" "application/json"}
-                               :on-done (fn [{:keys [success? xhr]}]
-                                            (if success?
-                                              (utils/rlog "Submission id: " ((utils/parse-json-string (.-responseText xhr)) "submissionId"))
-                                              (utils/rlog "Error: " (.-responseText xhr))))
-                               :canned-response {:responseText (utils/->json-string
-                                                                 [{"foo"        "fooValue"
-                                                                   "bar"        "barValue"
-                                                                   "attributes" {}}])
-                                                 :status 200 :delay-ms (rand-int 1000)}})
-                            )} "Launch"]]
-       ])}])
+                    ;; TODO: what should we show in the UI after submitting?
+                    ;; TODO: don't enable submit button until an entity has been selected
+                    ;; TODO: diable submit button after submitting
+                    :onClick (fn [e]
+                                 (let [expression (clojure.string/trim (-> (@refs "expressionname") .getDOMNode .-value))
+                                       payload (merge {:methodConfigurationNamespace (config "namespace")
+                                                       :methodConfigurationName (config "name")
+                                                       :entityType ((:selected-entity @state) "entityType")
+                                                       :entityName ((:selected-entity @state) "name")}
+                                                      (when-not (blank? expression) {:expression expression}))]
+                                      (utils/ajax-orch
+                                        (paths/submit-method-path workspace)
+                                        {:method :post
+                                         :data (utils/->json-string payload)
+                                         :headers{"Content-Type" "application/json"}
+                                         :on-done (fn [{:keys [success? xhr]}]
+                                                      ;; TODO total hack below for UI ...
+                                                      (if success?
+                                                        (set! (-> (@refs "launchContainer") .getDOMNode .-innerHTML) (.-responseText xhr))
+                                                        (do
+                                                          (set! (-> (@refs "launchContainer") .getDOMNode .-style .-backgroundColor) (:exception-red style/colors))
+                                                          (set! (-> (@refs "launchContainer") .getDOMNode .-innerHTML) (.-responseText xhr)))))
+                                         :canned-response {:responseText (utils/->json-string
+                                                                           [{"workspaceName" {"namespace" "broad-dsde-dev",
+                                                                                              "name" "alexb_test_submission"},
+                                                                             "methodConfigurationNamespace" "my_test_configs",
+                                                                             "submissionDate" "2015-08-18T150715.393Z",
+                                                                             "methodConfigurationName" "test_config2",
+                                                                             "submissionId" "62363984-7b85-4f27-b9c6-7577561f1326",
+                                                                             "notstarted" [],
+                                                                             "workflows" [{"messages" [],
+                                                                                           "workspaceName" {"namespace" "broad-dsde-dev",
+                                                                                                            "name" "alexb_test_submission"},
+                                                                                           "statusLastChangedDate" "2015-08-18T150715.393Z",
+                                                                                           "workflowEntity" {"entityType" "sample",
+                                                                                                             "entityName" "sample_01"},
+                                                                                           "status" "Submitted",
+                                                                                           "workflowId" "70521329-88fe-4288-9325-2e6183e0a9dc"}],
+                                                                             "status" "Submitted",
+                                                                             "submissionEntity" {"entityType" "sample",
+                                                                                                 "entityName" "sample_01"},
+                                                                             "submitter" "davidan@broadinstitute.org"}])
+                                                           :status 200 :delay-ms (rand-int 1000)}})
+                                      ))} "Launch"]]
+             ])}])
 
 (defn- render-main-display [state refs config editing?]
   [:div {:style {:marginLeft 330}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
@@ -195,7 +195,41 @@
                            (m "attributes")])
                      (:entities @state))}]])
         (style/create-form-label "Define Expression")
-        (style/create-text-field {})]])}])
+        (style/create-text-field {:ref "expressionname" :defaultValue "this"})]
+
+       [:div {:style {:fontSize "106%" :lineHeight 1 :textAlign "center"}}
+        [:div {:style   {:padding         "0.7em 0" :cursor "pointer"
+                         :backgroundColor (:button-blue style/colors)
+                         :color "#fff" :borderRadius 4
+                         :border          (str "1px solid " (:line-gray style/colors))}
+
+               ;; TODO: what should we show in the UI after submitting?
+               ;; TODO: if no expression entered, do not send one in the ajax request
+               ;; TODO: disable/enable submit button based on the state of entity selection & expression value
+               ;; TODO: diable submit button after submitting
+               ;; TODO: better canned response
+               :onClick (fn [{:keys []}]
+                            (utils/ajax-orch
+                              (paths/submit-method-path workspace)
+                              {:method :post
+                               :data (utils/->json-string {:methodConfigurationNamespace (config "namespace")
+                                                           :methodConfigurationName      (config "name")
+                                                           :entityType                   ((:selected-entity @state) "entityType")
+                                                           :entityName                   ((:selected-entity @state) "name")
+                                                           :expression                   (-> (@refs "expressionname") .getDOMNode .-value)
+                                                           })
+                               :headers {"Content-Type" "application/json"}
+                               :on-done (fn [{:keys [success? xhr]}]
+                                            (if success?
+                                              (utils/rlog "Submission id: " ((utils/parse-json-string (.-responseText xhr)) "submissionId"))
+                                              (utils/rlog "Error: " (.-responseText xhr))))
+                               :canned-response {:responseText (utils/->json-string
+                                                                 [{"foo"        "fooValue"
+                                                                   "bar"        "barValue"
+                                                                   "attributes" {}}])
+                                                 :status 200 :delay-ms (rand-int 1000)}})
+                            )} "Launch"]]
+       ])}])
 
 (defn- render-main-display [state refs config editing?]
   [:div {:style {:marginLeft 330}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/paths.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/paths.cljs
@@ -32,3 +32,6 @@
   (str "/workspaces/" (workspace "namespace") "/" (workspace "name") "/method_configs/copyFromMethodRepo"))
 
 (defn get-methods-path [] "/methods")
+
+(defn submit-method-path [workspace]
+      (str "/workspaces/" (workspace "namespace") "/" (workspace "name") "/submissions"))


### PR DESCRIPTION
This is a very early PR, since I know everybody is waiting on this: it adds a button to submit an analysis. However ...

*there is no feedback to the end user yet*, beyond browser console logging. So it's pretty incomplete, but hopefully I can get early code review, and others can get access to this functionality for their own testing.

Still left to do:
* success/error messaging to the user; something primitive, but we need something.
* allow the user to submit an empty expression, which then will use the rawls/cromwell defaults
* better canned response for development, when not using live data
