### PR TITLE
Show/hide columns

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -3,7 +3,8 @@
     [dmohs.react :as react]
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.icons :as icons]
-    [org.broadinstitute.firecloud-ui.common.style :as style]))
+    [org.broadinstitute.firecloud-ui.common.style :as style]
+    ))
 
 
 (react/defc Spinner
@@ -111,6 +112,24 @@
            (:items props))
          [:div {:style {:clear "both"}}]]
         [:div {} (:component (nth (:items props) (:active-tab-index @state)))]])}))
+
+
+(react/defc AnchoredDialog
+  {:render
+   (fn [{:keys [props]}]
+     (when (:show-when props)
+       (let [content (:content props)]
+         (assert (react/valid-element? content)
+           (subs (str "Not a react element: " content) 0 200))
+         [:div {:style {:backgroundColor "rgba(210, 210, 210, 0.4)"
+                        :overflowX "hidden" :overflowY "scroll"
+                        :position "fixed" :zIndex 8888
+                        :top 0 :right 0 :bottom 0 :left 0}
+                :onKeyDown (common/create-key-handler [:esc] #((:dismiss-self props)))
+                :onClick #((:dismiss-self props))}
+          [:div {:style {:position "absolute" :top (:anchor-top props) :left (:anchor-left props)}
+                 :onClick (fn [e] (.stopPropagation e))}
+           content]])))})
 
 
 (react/defc ModalDialog

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -141,7 +141,7 @@
                                (assert false "bad state"))
                              (swap! state assoc :sort-column i :sort-order :asc
                                :key-fn (if (= :value sorter)
-                                         (fn [row] (nth row i))
+                                         (fn [row] (str (nth row i)))
                                          (fn [row] (sorter (nth row i)))))))
             :sortOrder (when (= i (:sort-column @state)) (:sort-order @state))})))
      (filter :showing? (:ordered-columns @state)))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/launch_analysis.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/launch_analysis.cljs
@@ -54,7 +54,7 @@
                 [table/Table
                  {:key (name (gensym))
                   :columns (concat
-                             [{:header "" :starting-width 40 :resizable? false
+                             [{:header "" :starting-width 40 :resizable? false :reorderable? false
                                :content-renderer (fn [i data]
                                                    [:input {:type "radio"
                                                             :checked (identical? data (:selected-entity @state))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -117,7 +117,7 @@
        :header-row-style {:fontWeight nil :fontSize "90%"
                           :color (:text-light style/colors) :backgroundColor nil}
        :header-style {:padding "0 0 1em 14px" :overflow nil}
-       :resizable-columns? false
+       :resizable-columns? false :reorderable-columns? false
        :body-style {:fontSize nil :fontWeight nil
                     :borderLeft border-style :borderRight border-style
                     :borderBottom border-style :borderRadius 4}


### PR DESCRIPTION
This is the first half of the hide/reorder table columns story.  As such, much of the naming reflects the broader scope (things labeled "reorder") and there is some preparatory work for reordering that doesn't directly benefit show/hide.

Tables can now allow showing/hiding of columns via a `:reorderable-columns?` property, defaulting to true.  Individual columns can then have hiding (and later, reordering) disabled via `:reorderable?` on the column.  See the launch analysis dialog for a place where it's necessary to disable this.