### PR TITLE
Allow column resize drag to work outside the table's bounds

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -27,3 +27,17 @@
         elem-top (.-offsetTop elem)
         elem-bottom (+ elem-top (.-offsetHeight elem))]
     (and (< doc-view-top elem-top) (> doc-view-bottom elem-bottom))))
+
+
+(def ^:private user-select-keys ["userSelect" "webkitTouchCallout" "webkitUserSelect"
+                                 "mozUserSelect" "khtmlUserSelect" "msUserSelect"])
+
+(defn disable-text-selection []
+  (let [state (into {} (map (juxt identity #(aget (-> js/document .-body .-style) %)) user-select-keys))]
+    (doseq [k user-select-keys]
+      (aset (-> js/document .-body .-style) k "none"))
+    state))
+
+(defn restore-text-selection [state]
+  (doseq [k user-select-keys]
+    (aset (-> js/document .-body .-style) k (state k))))


### PR DESCRIPTION
This was a wild ride.  Making a checkpoint for a PR now so there isn't ever too much craziness at once.

I keep naming these branches things like "column drag" thinking I'm finally going to get around to working on drag-to-reorder, but I keep hitting things that need to get done first :/

This PR allows the column resizing gesture to work outside of the table itself.  To accomplish this, a mouse listener is added to the window rather than using onMouseMove on the table component itself.  This caused text to be selected wildly, so a new utility for disabling and restoring the text selection properties was created.