### PR TITLE
alternative UI  for rm an MC ; i've been able to import then delete methods with live data running orch. locally

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
@@ -109,7 +109,9 @@
    (fn [{:keys [props state]}]
      [:div {:style {:padding "1em 0"}}
       (if (:selected-method-config @state)
-        [MethodConfigEditor {:workspace-id (:workspace-id props)
+        [MethodConfigEditor {:on-rm (fn []
+                                      (swap! state dissoc :selected-method-config))
+                             :workspace-id (:workspace-id props)
                              :config (:selected-method-config @state)}]
         [MethodConfigurationsList
          {:workspace-id (:workspace-id props)

--- a/src/cljs/org/broadinstitute/firecloud_ui/paths.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/paths.cljs
@@ -41,3 +41,6 @@
 
 (defn list-submissions-path [workspace]
   (submit-method-path workspace))
+
+(defn rm-method-configuration-path [workspace-id config]
+  (update-method-config-path workspace-id config))


### PR DESCRIPTION
This UI/alternative lets the user click a button in the "edit an MC" screen,....not via a "trash" link in the main listing.

progress on deleting an MC

tidying and add confirmation box