### PR TITLE
make 'force workspace auth' link conditional on environment

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
@@ -106,11 +106,15 @@
           (if item
             [(item :component) {:nav-context nav-context}]
             [:div {} "Page not found."]))
-        [:div {:style {:margin "1em 1em -1em 0" :fontSize "smaller" :textAlign "right"}}
-         [:a {:href "https://rawls-dev.broadinstitute.org/authentication/register"
-              :target "_blank"
-              :style {:color "red"}}
-          "Force workspace service authentication"]]]))})
+        (let [currenthost (.-hostname (.-location js/window))]
+             (let [rawlsTarget (if (not= -1 (.indexOf currenthost "dsde-staging"))
+                   "https://rawls.dsde-staging.broadinstitute.org/authentication/register"
+                   "https://rawls-dev.broadinstitute.org/authentication/register")]
+          [:div {:style {:margin "1em 1em -1em 0" :fontSize "smaller" :textAlign "right"}}
+           [:a {:href rawlsTarget
+                :target "_blank"
+                :style {:color "red"}}
+            "Force workspace service authentication"]]))]))})
 
 ;; Content to display when logged out
 (react/defc LoggedOut


### PR DESCRIPTION
this is still very much a hack - I'm not putting effort into making this bulletproof or extensible, since we hope it disappears very soon.

(specifically, this means that "local.broadinstitute.org:8000" dev environments are still hardcoded to rawls-dev.)