### PR TITLE
icons now properly contained

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -174,11 +174,13 @@
       :size 24})
    :render
    (fn [{:keys [props]}]
-     (style/center {:style {:width (int (* 1.27 (:size props)))
-                            :height (int (* 1.27 (:size props)))
-                            :backgroundColor "fff" :borderRadius "100%"}}
-       (style/center {}
-         (icons/font-icon {:style {:color (:color props) :fontSize (int (* 0.5 (:size props)))}} :status-done))))})
+     [:span {:style {:display "inline-block" :position "relative" :verticalAlign "middle"
+                     :width (int (* 1.27 (:size props)))
+                     :height (int (* 1.27 (:size props)))
+                     :backgroundColor "fff" :borderRadius "100%"}}
+      (style/center {}
+        (icons/font-icon {:style {:color (:color props) :fontSize (int (* 0.5 (:size props)))}}
+          :status-done))])})
 
 (react/defc RunningIcon
   {:get-default-props
@@ -195,13 +197,14 @@
                                                 :borderRadius hamburger-height
                                                 :backgroundColor color}}])
            spacer [:div {:style {:height spacer-height}}]]
-       (style/center {}
-         [:div {}
-          (hamburger "white")
-          spacer
-          (hamburger (:color props))
-          spacer
-          (hamburger (:color props))])))})
+       [:span {:style {:display "inline-block" :position "relative" :verticalAlign :middle}}
+        (style/center {}
+          [:div {}
+           (hamburger "white")
+           spacer
+           (hamburger (:color props))
+           spacer
+           (hamburger (:color props))])]))})
 
 (react/defc ExceptionIcon
   {:get-default-props
@@ -209,5 +212,6 @@
      {:size 24})
    :render
    (fn [{:keys [props]}]
-     (style/center {}
-      (icons/font-icon {:style {:color "#fff" :fontSize (:size props)}} :status-warning)))})
+     [:span {:style {:display "inline-block" :position "relative" :verticalAlign "middle"}}
+      (style/center {}
+        (icons/font-icon {:style {:color "#fff" :fontSize (:size props)}} :status-warning))])})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
@@ -111,9 +111,8 @@
                                    (when confirmed?
                                      (do (swap! state assoc :deleting? true)
                                          (react/call :rm-mc this)))))}
-                [:span {:style {:display "inline-block" :verticalAlign "middle"}}
-                 (icons/font-icon {:style {:fontSize "135%"}} :trash-can)]
-                [:span {:style {:marginLeft "1em"}} "Delete"]]))})
+                (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} :trash-can)
+                [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} "Delete"]]))})
 
 
 (defn- render-side-bar [state refs config editing? props]
@@ -129,9 +128,8 @@
                        :backgroundColor "transparent" :color (:button-blue style/colors)
                        :border (str "1px solid " (:line-gray style/colors))}
                :onClick #(swap! state assoc :editing? true :prereqs-list (vals (config "prerequisites")))}
-         [:span {:style {:display "inline-block" :verticalAlign "middle"}}
-          (icons/font-icon {:style {:fontSize "135%"}} :pencil)]
-         [:span {:style {:marginLeft "1em"}} "Edit this page"]])
+         (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} :pencil)
+         [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} "Edit this page"]])
 
       (when-not editing?
         [DeleteButton
@@ -143,17 +141,15 @@
         [:div {:style {:padding "0.7em 0" :cursor "pointer"
                        :backgroundColor (:success-green style/colors) :color "#fff" :borderRadius 4}
                :onClick #(do (commit state refs config props) (stop-editing state refs))}
-         [:span {:style {:display "inline-block" :verticalAlign "middle"}}
-          (icons/font-icon {:style {:fontSize "135%"}} :status-done)]
-         [:span {:style {:marginLeft "1em"}} "Save"]])
+         (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} :status-done)
+         [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} "Save"]])
 
       (when editing?
         [:div {:style {:padding "0.7em 0" :marginTop "0.5em" :cursor "pointer"
                        :backgroundColor (:exception-red style/colors) :color "#fff" :borderRadius 4}
                :onClick #(stop-editing state refs)}
-         [:span {:style {:display "inline-block" :verticalAlign "middle"}}
-          (icons/font-icon {:style {:fontSize "135%"}} :x)]
-         [:span {:style {:marginLeft "1em"}} "Cancel Editing"]])])])
+         (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} :x)
+         [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} "Cancel Editing"]])])])
 
 (defn- render-launch-analysis [state workspace-id editing?]
   [:div {:style {:width 200 :float "right" :display (when editing? "none")}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary_tab.cljs
@@ -37,28 +37,23 @@
         :else
         (let [ws (get-in @state [:server-response :workspace])]
           [:div {:style {:margin "45px 25px"}}
-           [:div {:style {:float "left" :display "inline-block" :width 290 :marginRight 40}}
+           [:div {:style {:float "left" :width 290 :marginRight 40}}
             ;; TODO - make the width of the float-left dynamic
-            [:div {:style {:borderRadius 5 :padding 25 :textAlign "center"
+            [:div {:style {:borderRadius 5 :padding 20 :textAlign "center"
                            :color "#fff"
                            :backgroundColor (style/color-for-status (ws "status"))
                            :fontSize "125%" :fontWeight 400}}
-             [:span {:style {:display "inline-block" :marginRight 14 :marginTop -4
-                             :verticalAlign "middle" :position "relative"}}
-              (case (ws "status")
-                "Complete" [comps/CompleteIcon {:size 36}]
-                "Running" [comps/RunningIcon {:size 36}]
-                "Exception" [comps/ExceptionIcon {:size 36}])]
+             (case (ws "status")
+               "Complete" [comps/CompleteIcon {:size 36}]
+               "Running" [comps/RunningIcon {:size 36}]
+               "Exception" [comps/ExceptionIcon {:size 36}])
              [:span {:style {:marginLeft "1.5ex"}} (ws "status")]]
-            [:div {:style {:marginTop 27}}
-             [:div {:style {:backgroundColor "transparent" :color (:button-blue style/colors)
-                            :border (str "1px solid " (:line-gray style/colors))
-                            :fontSize "106%" :lineHeight 1 :position "relative"
-                            :padding "0.7em 0em"
-                            :textAlign "center" :cursor "pointer"}}
-              [:span {:style {:display "inline-block" :verticalAlign "middle"}}
-               (icons/font-icon {:style {:fontSize "135%"}} :pencil)]
-              [:span {:style {:marginLeft "1em"}} "Edit this page"]]]]
+            [:div {:style {:backgroundColor "transparent" :color (:button-blue style/colors)
+                           :border (str "1px solid " (:line-gray style/colors))
+                           :fontSize "106%" :padding "0.7em 0em" :marginTop 27
+                           :cursor "pointer" :textAlign "center"}}
+             (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} :pencil)
+             [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} "Edit this page"]]]
            [:div {:style {:display "inline-block"}}
             (create-section-header "Workspace Owner")
             (create-paragraph

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -84,10 +84,11 @@
               :onClick #((get-in props [:data :onClick]))}
         [:div {:style {:backgroundColor "rgba(0,0,0,0.2)"
                        :position "absolute" :top 0 :right 0 :bottom 0 :left 2}}]
-        (case status
-          "Complete"  [comps/CompleteIcon]
-          "Running"   [comps/RunningIcon]
-          "Exception" [comps/ExceptionIcon])]))})
+        (style/center {}
+          (case status
+            "Complete"  [comps/CompleteIcon]
+            "Running"   [comps/RunningIcon]
+            "Exception" [comps/ExceptionIcon]))]))})
 
 
 (react/defc WorkspaceCell


### PR DESCRIPTION
Very little visual change on this one.

Previously, the custom icons in components.cljs were not contained properly and wanted to center in their parent component, requiring extra external effort to override this.  So there's actually *more* code around some usages of them now, but now it's easier to use them across the board.