### PR TITLE
Refactor import method configuration

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
@@ -8,8 +8,8 @@
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.paths :as paths]
-    [org.broadinstitute.firecloud-ui.utils :as utils]))
-
+    [org.broadinstitute.firecloud-ui.utils :as utils]
+    ))
 
 (defn create-post-data
   [selected-conf-name
@@ -30,124 +30,137 @@
        :url (str "http://agora-ci.broadinstitute.org/configurations/joel_test/jt_test_config/1")
        :namespace (rand-nth ["Broad" "nci" "public" "ISB"])
        :snapshotId (rand-nth (range 100))
-       :synopsis (str (rand-nth ["variant caller synopsis","gene analyzer synopsis","mutect synopsis"]) " " (inc i))
-       :createDate (str "20"(inc i) "-06-10T16:54:26Z")
-       :owner (rand-nth ["thibault@broadinstitute.org" "esalinas@broadinstitute.org"  ])})
+       :synopsis (str (rand-nth ["variant caller synopsis", "gene analyzer synopsis", "mutect synopsis"]) " " (inc i))
+       :createDate (str "20" (inc i) "-06-10T16:54:26Z")
+       :owner (rand-nth ["thibault@broadinstitute.org" "esalinas@broadinstitute.org"])})
     (range (rand-int 50))))
 
+(defn- create-formatted-label-text [label text]
+  [:div {:style {:padding "10px 0 10px 0"}}
+   [:div {:style {:float "left" :width "180px"}} label ": "] [:div {} text]])
 
-(react/defc ModalImportOptionsAndButton
-  {:render (fn [{:keys [state props refs]}]
-             (let [selected-conf-name (get  props :init-Name)
-                   selected-conf-namespace (get props :init-Namespace)
-                   selected-conf-snapshotId (get props :init-SnapshotId)
-                   workspace-id (:workspace-id props)
-                   dest-workspace-name (:name workspace-id)
-                   dest-workspace-namespace (:namespace workspace-id)]
-               [:div {:style {:backgroundColor (:background-gray style/colors)}}
-                [:div {}
-                 "Destination Name : "
-                 (style/create-text-field {:defaultValue selected-conf-name :ref "destinationName"})]
-                "Destination Namespace : "
-                (style/create-text-field
-                  {:defaultValue selected-conf-namespace
-                   :ref "destinationNamespace"})
-                [:br]
-                [comps/Button
-                 {:title-text "import selected"
-                  :icon :plus
-                  :onClick (fn []
-                             (let [dest-conf-name (.-value (.getDOMNode (@refs "destinationName")))
-                                   dest-conf-namespace (.-value (.getDOMNode (@refs "destinationNamespace")))
-                                   post-data (create-post-data
-                                               selected-conf-name
-                                               selected-conf-namespace
-                                               selected-conf-snapshotId
-                                               dest-conf-name
-                                               dest-conf-namespace)]
-                               (utils/ajax-orch
-                                 (paths/copy-method-config-to-workspace-path workspace-id)
-                                 {:headers {"Content-Type" "application/json"}
-                                  :canned-response {:responseText
-                                                      (utils/->json-string (create-mock-methodconfs-import))
-                                                    :status 200
-                                                    :delay-ms (rand-int 2000)}
-                                  :method :post
-                                  :data (utils/->json-string post-data)
-                                  :on-done (fn [{:keys [success? xhr]}]
-                                             (if success?
-                                               ((:on-import props))
-                                               (js/alert (str "Error in import : "  (.-statusText xhr)))))})))}]]))})
+(defn- create-formatted-label-textfield [label textfield]
+  [:div {}
+   [:div {:style {:float "left" :width "180px" :paddingTop "10px"}} label ": "] [:div {} textfield]])
 
+(defn- create-formatted-header [text]
+  [:div {}
+   [:div {:style {:fontSize 24 :align "center" :textAlign "center" :paddingBottom "0.5em"}} text]
+   [:hr]])
 
-(defn render-import-modal [config props refs on-close on-import]
-  [comps/Dialog
-   {:width 750
-    :dismiss-self on-close
-    :content (react/create-element
-               [:div {}
-                [:div {:style {:backgroundColor "#fff"
-                               :borderBottom (str "1px solid " (:line-gray style/colors))
-                               :padding "20px 48px 18px"
-                               :fontSize "137%" :fontWeight 400 :lineHeight 1}}
-                 "Import a Method Configuration"
-                 [:hr]
-                 (config "name") [:br]
-                 (config "namespace") [:br]
-                 (config "snapshotId")]
-                 [:div {:style {:position "absolute" :right 2 :top 2}}
-                  [:div {:style {:backgroundColor (:button-blue style/colors) :color "#fff"
-                                 :padding "0.5em" :cursor "pointer"}
-                         :onClick on-close}
-                   (icons/font-icon {:style {:fontSize "60%"}} :x)]]
-                [:div {:style {:padding "22px 48px 40px"
-                               :backgroundColor (:background-gray style/colors)}}
-                 [ModalImportOptionsAndButton {:init-Name (config "name")
-                                               :init-Namespace (config "namespace")
-                                               :init-SnapshotId (config "snapshotId")
-                                               :on-import on-import
-                                               :workspace-id (:workspace-id props)}]]])}])
+(defn- render-import-button [props refs]
+  (let [selected-config (:selected-method-config props)
+        selected-conf-name (selected-config "name")
+        selected-conf-namespace (selected-config "namespace")
+        selected-conf-snapshot-id (selected-config "snapshotId")
+        workspace-id (:workspace-id props)
+        on-import (:on-import props)]
+    [comps/Button
+     {:text "Import"
+      :onClick (fn []
+                 (let [dest-conf-name (-> (@refs "destinationName") .getDOMNode .-value)
+                       dest-conf-namespace (-> (@refs "destinationNamespace") .getDOMNode .-value)
+                       post-data (create-post-data
+                                   selected-conf-name
+                                   selected-conf-namespace
+                                   selected-conf-snapshot-id
+                                   dest-conf-name
+                                   dest-conf-namespace)]
+                   (utils/ajax-orch
+                     (paths/copy-method-config-to-workspace-path workspace-id)
+                     {:headers {"Content-Type" "application/json"}
+                      :canned-response {:responseText
+                                        (utils/->json-string (create-mock-methodconfs-import))
+                                        :status 200
+                                        :delay-ms (rand-int 2000)}
+                      :method :post
+                      :data (utils/->json-string post-data)
+                      :on-done (fn [{:keys [success? xhr]}]
+                                 (if success?
+                                   (on-import)
+                                   (js/alert (str "Import Error: " (.-responseText xhr)))))})))}]))
 
 
-(react/defc ImportWorkspaceMethodsConfigurationsList
+(react/defc ConfigurationImportForm
   {:render
-   (fn [{:keys [state props refs]}]
+   (fn [{:keys [props refs]}]
+     (let [selected-config (:selected-method-config props)
+           selected-conf-name (selected-config "name")
+           selected-conf-namespace (selected-config "namespace")
+           selected-conf-snapshot-id (selected-config "snapshotId")
+           workspace-id (:workspace-id props)
+           on-import (:on-import props)]
+       (assert selected-config (str "Missing a selected configuration: " props))
+       (assert on-import (str "Missing on-import handler: " props))
+       (assert workspace-id (str "Missing workspace-id: " props))
+       [:div {}
+        (create-formatted-header "Import Method Configuration")
+        (for [[k v] {"Name" selected-conf-name
+                     "Namespace" selected-conf-namespace
+                     "Snapshot Id" selected-conf-snapshot-id
+                     }] (create-formatted-label-text k v))
+        (for [[k v] {"Destination Name"
+                     (style/create-text-field {:defaultValue selected-conf-name :ref "destinationName"})
+                     "Destination Namespace"
+                     (style/create-text-field {:defaultValue selected-conf-namespace :ref "destinationNamespace"})}]
+          (create-formatted-label-textfield k v))
+        (render-import-button props refs)]))})
+
+
+(react/defc ConfigurationsTable
+  {:render
+   (fn [{:keys [props]}]
+     (let [on-config-selected (:on-config-selected props)
+           method-configs (:method-configs props)]
+       (assert on-config-selected (str "Missing an on-selected-config handler: " props))
+       (assert method-configs (str "Missing a list of method configs: " props))
+       [:div {}
+        (create-formatted-header "Select A Method Configuration For Import")
+        [table/Table
+         {:columns [{:header "Name" :starting-width 200 :filter-by #(% "name") :sort-by #(% "name")
+                     :content-renderer
+                     (fn [row-index conf]
+                       [:a
+                        {:onClick
+                         (fn []
+                           (on-config-selected conf))
+                         :href "javascript:;"
+                         :style {:color (:button-blue style/colors) :textDecoration "none"}}
+                        (conf "name")])}
+                    {:header "Namespace" :starting-width 200 :sort-by :value}
+                    {:header "Snapshot Id" :starting-width 100 :sort-by :value}
+                    {:header "Synopsis" :starting-width 160 :sort-by :value}
+                    {:header "Create Date" :starting-width 210 :sort-by :value}
+                    {:header "Owner" :starting-width 290 :sort-by :value}]
+          :data (map
+                  (fn [config]
+                    [config
+                     (config "namespace")
+                     (config "snapshotId")
+                     (config "synopsis")
+                     (config "createDate")
+                     (config "owner")])
+                  method-configs)}]]))})
+
+
+(react/defc ModalPage
+  {:render
+   (fn [{:keys [state props]}]
      [:div {}
-      (when (:show-import-mc-modal? @state)
-        (render-import-modal (:selected-conf @state) props refs
-                             #(swap! state dissoc :show-import-mc-modal?)
-                             (fn [& args]
-                               (swap! state dissoc :show-import-mc-modal?)
-                               (apply (:on-import props) args))))
       (cond
-        (:loaded-import-confs? @state)
-        (if (zero? (count (:method-confs @state)))
-          (style/create-message-well "There are no method configurations to display for import!")
-          [table/Table
-           {:columns [{:header "Name" :starting-width 200 :filter-by #(% "name") :sort-by #(% "name")
-                       :content-renderer
-                       (fn [row-index conf]
-                         [:a
-                          {:onClick
-                           (fn []
-                             (swap! state assoc :selected-conf conf :show-import-mc-modal? true))
-                           :href "javascript:;"
-                           :style {:color (:button-blue style/colors) :textDecoration "none"}}
-                          (conf "name")])}
-                      {:header "Namespace" :starting-width 200 :sort-by :value}
-                      {:header "Snapshot Id" :starting-width 100 :sort-by :value}
-                      {:header "Synopsis" :starting-width 160 :sort-by :value}
-                      {:header "Create Date" :starting-width 210 :sort-by :value}
-                      {:header "Owner" :starting-width 290 :sort-by :value}]
-            :data (map
-                    (fn [config]
-                      [config
-                       (config "namespace")
-                       (config "snapshotId")
-                       (config "synopsis")
-                       (config "createDate")
-                       (config "owner")])
-                    (:method-confs @state))}])
+        (:show-import-mc-modal? @state) [ConfigurationImportForm {:selected-method-config (:selected-method-config @state)
+                                                                  :workspace-id (:workspace-id props)
+                                                                  :on-import (fn [& args]
+                                                                               (swap! state dissoc :show-import-mc-modal?)
+                                                                               (apply (:on-import props) args))}]
+        (:loaded-import-confs? @state) (if (zero? (count (:method-configs @state)))
+                                         (style/create-message-well "There are no method configurations to display for import!")
+                                         [ConfigurationsTable {:method-configs (:method-configs @state)
+                                                               :on-config-selected (fn [config]
+                                                                                     (swap! state assoc
+                                                                                       :selected-method-config config
+                                                                                       :show-import-mc-modal? true
+                                                                                       :loaded-import-confs? false))}])
         (:error-message @state) [:div {:style {:color "red"}}
                                  "FireCloud service returned error: " (:error-message @state)]
         :else [comps/Spinner {:text "Loading configurations for import..."}])])
@@ -155,43 +168,19 @@
    (fn [{:keys [state]}]
      (utils/call-ajax-orch "/configurations"
        {:on-success (fn [{:keys [parsed-response]}]
-                      (swap! state assoc :loaded-import-confs? true :method-confs parsed-response))
+                      (swap! state assoc :loaded-import-confs? true :method-configs parsed-response))
         :on-failure (fn [{:keys [status-text]}]
                       (swap! state assoc :error-message status-text))
         :mock-data (create-mock-methodconfs-import)}))})
 
-
-(def modal-import-background
-  {:backgroundColor "rgba(82, 129, 197, 0.4)"
-   :overflowX "hidden" :overflowY "scroll"
-   :position "fixed" :zIndex 9999
-   :top 0 :right 0 :bottom 0 :left 0})
-
-
-(def ^:private modal-import-content
-  {:transform "translate(-50%, 0px)"
-   :backgroundColor (:background-gray style/colors)
-   :position "relative" :marginBottom 60
-   :top 60
-   :left "50%"
-   :width "90%"})
-
-
 (defn render-import-overlay [workspace-id on-close on-import]
-  [:div {:style modal-import-background
-         :onKeyDown (common/create-key-handler [:esc] on-close)}
-   [:div {:style modal-import-content}
-    [:div {:style {:position "absolute" :right 2 :top 2}}
-     [:div {:style {:backgroundColor (:button-blue style/colors) :color "#fff"
-                    :padding "0.5em" :cursor "pointer"}
-            :onClick #(on-close)}
-      (icons/font-icon {:style {:fontSize "60%"}} :x)]]
-    [:div {:style {:backgroundColor "#fff"
-                   :borderBottom (str "1px solid " (:line-gray style/colors))
-                   :padding "20px 48px 18px"}}
-     [:div {:style {:fontSize 24 :align "center" :textAlign "center" :paddingBottom "0.5em"}}
-      "Select A Method Configuration For Import"]
-     [ImportWorkspaceMethodsConfigurationsList {:workspace-id workspace-id
-                                                :on-close on-close
-                                                :on-import on-import}]
-     [:div {:style {:paddingTop "0.5em"}}]]]])
+  (react/create-element
+    [:div {}
+     [:div {:style {:position "absolute" :right 2 :top 2}}
+      [:div {:style {:backgroundColor (:button-blue style/colors) :color "#fff" :padding "0.5em" :cursor "pointer"}
+             :onClick #(on-close)}
+       (icons/font-icon {:style {:fontSize "60%"}} :x)]]
+     [:div {:style {:backgroundColor "#fff" :borderBottom (str "1px solid " (:line-gray style/colors))
+                    :padding "20px 48px 18px"}}
+      [ModalPage {:workspace-id workspace-id :on-close on-close :on-import on-import}]
+      [:div {:style {:paddingTop "0.5em"}}]]]))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
@@ -52,9 +52,13 @@
    (fn [{:keys [props state]}]
      [:div {}
       (when (:show-import-overlay? @state)
-        (importmc/render-import-overlay (:workspace-id props)
-         #(swap! state dissoc :show-import-overlay?)
-         #(swap! state dissoc :show-import-overlay? :server-response)))
+        [comps/Dialog
+         {:blocker? true
+          :width "80%"
+          :dismiss-self #(swap! state dissoc :show-import-overlay?)
+          :content (importmc/render-import-overlay (:workspace-id props)
+                     #(swap! state dissoc :show-import-overlay?)
+                     #(swap! state dissoc :show-import-overlay? :server-response))}])
       [:div {:style {:float "right" :padding "0 2em 1em 0"}}
        [comps/Button {:text "Import Configuration ..."
                       :onClick #(swap! state assoc :show-import-overlay? true)}]]


### PR DESCRIPTION
My first (official) attempt at refactoring the import method configuration screen for DSDEEPB-1072

Notes:
* Tried to consolidate each view into its own discrete react component
* Tried to clean up the style a bit
* Removed the passing of state to components and instead only pass what is needed.

What this does not do:
* Does not redirect to the newly imported configuration as specified in the story. That requires more clojure-foo than I can muster at the moment.
