### PR TITLE
Import Method Configuration Refactor

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
@@ -77,7 +77,7 @@
                       :data (utils/->json-string post-data)
                       :on-done (fn [{:keys [success? xhr]}]
                                  (if success?
-                                   (on-import)
+                                   (on-import {"name" dest-conf-name "namespace" dest-conf-namespace})
                                    (js/alert (str "Import Error: " (.-responseText xhr)))))})))}]))
 
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
@@ -58,7 +58,7 @@
           :dismiss-self #(swap! state dissoc :show-import-overlay?)
           :content (importmc/render-import-overlay (:workspace-id props)
                      #(swap! state dissoc :show-import-overlay?)
-                     #(swap! state dissoc :show-import-overlay? :server-response))}])
+                     (:on-config-imported props))}])
       [:div {:style {:float "right" :padding "0 2em 1em 0"}}
        [comps/Button {:text "Import Configuration ..."
                       :onClick #(swap! state assoc :show-import-overlay? true)}]]
@@ -132,7 +132,10 @@
                              :config (:selected-method-config @state)}]
         [MethodConfigurationsList
          {:workspace-id (:workspace-id props)
+          ;TODO: For both callbacks - rename config to config-id and follow the workspace-id pattern
           :on-config-selected (fn [config]
+                                (swap! state assoc :selected-method-config config))
+          :on-config-imported (fn [config]
                                 (swap! state assoc :selected-method-config config))}])])
    :component-will-receive-props
    (fn [{:keys [state]}]


### PR DESCRIPTION
For DSDEEPB-1072 

Update import method configuration so that it redirects to the after the configuration is successfully imported.

Notes:
* We need to treat config similarly to the way we do workspace - it should be an object with name and namespace.