### PR TITLE
Use Moment.js on submissions stuff

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
    [org.clojure/clojure "1.7.0"]
    [org.clojure/clojurescript "1.7.48"]
    [inflections "0.9.14"]
+   [cljsjs/moment "2.9.0-3"]
    ]
   :plugins [[lein-cljsbuild "1.0.6"] [lein-figwheel "0.3.7"]]
   :hooks [leiningen.cljsbuild]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor_tab.cljs
@@ -1,6 +1,7 @@
 (ns org.broadinstitute.firecloud-ui.page.workspace.monitor-tab
   (:require
     [dmohs.react :as react]
+    cljsjs.moment
     [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.common.table :as table]
@@ -15,13 +16,12 @@
     (fn [i]
       {:workspaceName workspace-id
        :methodConfigurationNamespace "my_test_configs"
-       :submissionDate (str "2015-" (inc (rand-int 12)) "-" (inc (rand-int 30)) "T19:08:53.027Z")
+       :submissionDate (utils/rand-recent-time)
        :submissionId "46bfd579-b1d7-4f92-aab0-e44dd092b52a"
        :notstarted []
        :workflows [{:messages []
                     :workspaceName workspace-id
-                    :statusLastChangedDate (str "2015-" (inc (rand-int 12)) "-" (inc (rand-int 30))
-                                             "T19:08:53.027Z")
+                    :statusLastChangedDate (utils/rand-recent-time)
                     :workflowEntity {:entityType "sample"
                                      :entityName "sample_01"}
                     :status "Succeeded"
@@ -43,7 +43,7 @@
                           [:a {:href "javascript:;"
                                :style {:color (:button-blue style/colors) :textDecoration "none"}
                                :onClick #(on-submission-clicked (submission "submissionId"))}
-                           (submission "submissionDate")])}
+                           (.format (js/moment (submission "submissionDate")) "LLL")])}
      {:header "Status" :sort-by :value}
      {:header "Method Configuration" :starting-width 220 :sort-by :value}
      {:header "Data Entity" :starting-width 220 :sort-by :value}]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/submission_details.cljs
@@ -1,6 +1,7 @@
 (ns org.broadinstitute.firecloud-ui.page.workspace.submission-details
   (:require
     [dmohs.react :as react]
+    cljsjs.moment
     [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.common.icons :as icons]
     [org.broadinstitute.firecloud-ui.common.style :as style]
@@ -11,7 +12,7 @@
 
 (defn- create-mock-submission-details [submission-id]
   {"submissionId" submission-id
-   "submissionDate" (str "2015-" (inc (rand-int 12)) "-" (inc (rand-int 30)) "T19:08:53.027Z")
+   "submissionDate" (utils/rand-recent-time)
    "submitter" "test@test.gov"
    "methodConfigurationNamespace" "broad-dsde-dev"
    "methodConfigurationName" "some method conf"
@@ -20,8 +21,7 @@
    "workflows" (map (fn [i]
                       {"messages" []
                        "workspaceName" "foo"
-                       "statusLastChangedDate" (str "2015-" (inc (rand-int 12)) "-" (inc (rand-int 30))
-                                                 "T19:08:53.027Z")
+                       "statusLastChangedDate" (utils/rand-recent-time)
                        "workflowEntity" {"entityType" "sample"
                                          "entityName" (str "sample_" i)}
                        "status" (rand-nth ["Succeeded" "Submitted" "Running" "Failed" "Aborted" "Unknown"])
@@ -75,7 +75,11 @@
           {:columns [{:header "Data Entity" :starting-width 200 :sort-by :value
                       :filter-by (fn [entity]
                                    (str (entity "entityType") " " (entity "entityName")))}
-                     {:header "Last Changed" :starting-width 200 :sort-by :value}
+                     {:header "Last Changed" :starting-width 280 :sort-by :value
+                      :content-renderer (fn [row-index date]
+                                          (let [m (js/moment date)]
+                                            (str (.format m "L [at] LTS") " ("
+                                                 (.fromNow m) ")")))}
                      {:header "Status" :starting-width 120 :sort-by :value
                       :content-renderer (fn [row-index status]
                                           [:div {}
@@ -168,7 +172,8 @@
            (style/create-section-header "Submitted by")
            (style/create-paragraph
              [:div {} (submission "submitter")]
-             [:div {} (submission "submissionDate")])
+             (let [m (js/moment (submission "submissionDate"))]
+               [:div {} (.format m "LLL") " (" (.fromNow m) ")"]))
            (style/create-section-header "Submission ID")
            (style/create-paragraph (submission "submissionId"))]
           [:div {:style {:clear "both" :paddingBottom "0.5em"}} "Workflows:"]

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -160,3 +160,6 @@
 
 (defn rand-subset [items]
   (take (rand-int (count items)) (shuffle items)))
+
+(defn rand-recent-time []
+  (.format (.subtract (js/moment (js/Date.)) (rand-int 100000) "seconds")))


### PR DESCRIPTION
Added Moment.js, and used some of its functionality to better generate random times for mock data, and to render absolute and relative times in the submissions list and details page.

Note for future use:  Including Moment.js causes the compiled javascript to include a global "moment" function.  This makes it a runtime error to try to bind a Moment to a variable called "moment".