### PR TITLE
Fixed null reference error with empty tables

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -384,10 +384,6 @@
      (let [rows (react/call :get-filtered-data this)]
        (react/call :set-rows (@refs "body") (react/call :get-body-rows this rows))
        (react/call :set-num-rows-visible (@refs "paginator") (count rows))))
-   :component-will-receive-props
-   (fn [{:keys [props state refs]}]
-     (swap! state assoc :ordered-columns (create-ordered-columns (:columns props)))
-     (react/call :make-desynced (@refs "filterer")))
    :component-did-mount
    (fn [{:keys [this state]}]
      (set! (.-onMouseMoveHandler this)


### PR DESCRIPTION
On the method configs tab with no method configs, trying to click the import button trips here because there is no filterer.  This sort of seems like a hack though...