### PR TITLE
Focus work for dialogs

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -5,11 +5,13 @@
   {:backspace 8 :tab 9 :enter 13 :shift 16 :ctrl 17 :alt 18 :capslock 20 :esc 27 :space 32
    :pgup 33 :pgdown 34 :end 35 :home 67 :left 37 :up 38 :right 39 :down 40 :insert 45 :del 46})
 
-(defn create-key-handler [keys func]
-  (fn [e]
-    (let [keycode (.-keyCode e)]
-      (when (some #(= keycode (% keymap)) keys)
-        (func e)))))
+(defn create-key-handler
+  ([keys func] (create-key-handler keys (fn [e] true) func))
+  ([keys modifier func] (fn [e]
+                          (when (modifier e)
+                            (let [keycode (.-keyCode e)]
+                              (when (some #(= keycode (% keymap)) keys)
+                                (func e)))))))
 
 (defn clear! [refs & ids]
   (doseq [id ids]
@@ -41,3 +43,8 @@
 (defn restore-text-selection [state]
   (doseq [k user-select-keys]
     (aset (-> js/document .-body .-style) k (state k))))
+
+(defn focus-and-select [dom-node]
+  (.focus dom-node)
+  (when (= "text" (.-type dom-node))
+    (.select dom-node)))

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -124,7 +124,8 @@
 (react/defc Dialog
   {:get-default-props
    (fn []
-     {:blocking? true})
+     {:blocking? true
+      :cycle-focus? false})
    :render
    (fn [{:keys [props state]}]
      (let [content (:content props)
@@ -157,9 +158,13 @@
        (common/focus-and-select (get-first))
        (when-let [get-last (:get-last-element-dom-node props)]
          (.addEventListener (get-first) "keydown" (common/create-key-handler [:tab] #(.-shiftKey %)
-                                                    (fn [e] (.preventDefault e) (.focus (get-last)))))
+                                                    (fn [e] (.preventDefault e)
+                                                      (when (:cycle-focus? props)
+                                                        (.focus (get-last))))))
          (.addEventListener (get-last) "keydown" (common/create-key-handler [:tab] #(not (.-shiftKey %))
-                                                   (fn [e] (.preventDefault e) (.focus (get-first)))))))
+                                                   (fn [e] (.preventDefault e)
+                                                     (when (:cycle-focus? props)
+                                                       (.focus (get-first))))))))
      (set! (.-onKeyDownHandler this)
            (common/create-key-handler [:esc] #((:dismiss-self props))))
      (.addEventListener js/window "keydown" (.-onKeyDownHandler this)))

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -153,6 +153,13 @@
      (when-let [get-dom-node (:get-anchor-dom-node props)]
        (swap! state assoc :position {:top (.. (get-dom-node) -offsetTop)
                                      :left (.. (get-dom-node) -offsetLeft)}))
+     (when-let [get-first (:get-first-element-dom-node props)]
+       (common/focus-and-select (get-first))
+       (when-let [get-last (:get-last-element-dom-node props)]
+         (.addEventListener (get-first) "keydown" (common/create-key-handler [:tab] #(.-shiftKey %)
+                                                    (fn [e] (.preventDefault e) (.focus (get-last)))))
+         (.addEventListener (get-last) "keydown" (common/create-key-handler [:tab] #(not (.-shiftKey %))
+                                                   (fn [e] (.preventDefault e) (.focus (get-first)))))))
      (set! (.-onKeyDownHandler this)
            (common/create-key-handler [:esc] #((:dismiss-self props))))
      (.addEventListener js/window "keydown" (.-onKeyDownHandler this)))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -50,7 +50,7 @@
             :onClick #(clear-overlay state refs)
             :onKeyDown (common/create-key-handler [:space :enter] #(clear-overlay state refs))}
         "Cancel"]
-       [comps/Button {:text "Create Workspace"
+       [comps/Button {:text "Create Workspace" :ref "createButton"
                       :onClick
                       #(let [ns (-> (@refs "wsNamespace") .getDOMNode .-value clojure.string/trim)
                              n (-> (@refs "wsName") .getDOMNode .-value clojure.string/trim)]
@@ -229,7 +229,9 @@
           [comps/Dialog
            {:width 500
             :dismiss-self #(swap! state dissoc :overlay-shown?)
-            :content (render-modal state refs nav-context)}])
+            :content (render-modal state refs nav-context)
+            :get-first-element-dom-node #(.getDOMNode (@refs "wsNamespace"))
+            :get-last-element-dom-node #(.getDOMNode (@refs "createButton"))}])
         [:div {:style {:padding "2em"}}
          [:div {:style {:float "right" :display (when (:name selected-ws-id) "none")}}
           [comps/Button


### PR DESCRIPTION
Dialogs can now specify three more properties:

* `:get-first-element-dom-node` -- When specified, this component is focused (and selected if it's a text component) when the dialog is shown.
* `:get-last-element-dom-node` -- When additionally specified, key handlers are added to the first and last items to constrain focus in the dialog.
* `:cycle-focus?` (defaults to false) -- When both first and last are specified, this controls whether or not the focus should cycle.  When true, tabbing from the last component focuses the first, and shift-tabbing from the first focuses the last.  When false, focus traversal is simply blocked on each end.