### PR TITLE
enter the method-config table from repo for browsing

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
@@ -5,23 +5,41 @@
    [org.broadinstitute.firecloud-ui.common.style :as style]
    [org.broadinstitute.firecloud-ui.common.table :as table]
    [org.broadinstitute.firecloud-ui.paths :refer [get-methods-path]]
+   [org.broadinstitute.firecloud-ui.page.workspace.method-config-importer :as importmc]
    [org.broadinstitute.firecloud-ui.utils :as utils]
    ))
 
 
 (react/defc MethodsList
   {:render
-   (fn [{:keys [props]}]
+   (fn [{:keys [props state]}]
+     (if (:show-import-overlay? @state)
+       [comps/Dialog
+        {:blocking? true
+         :width "80%"
+         :dismiss-self #(swap! state dissoc :show-import-overlay?)
+         :content  (importmc/render-import-overlay
+                     nil ; nil workspace because entrypoint is  from method repo
+                     #(swap! state dissoc :show-import-overlay?) ; on-close
+                     nil ; on-import nil because entry from method re
+                     (:selected-method @state))}]
      [table/Table
       {:empty-message "No methods to display."
        :columns [{:header "Namespace" :starting-width 150 :sort-by :value}
-                 {:header "Name" :starting-width 150 :sort-by :value}
+                 {:header "Name" :starting-width 150 :sort-by :value
+                  :content-renderer (fn [row-index msm]
+                                      [:a {:style {:color (:button-blue style/colors)
+                                                   :textDecoration "none"}
+                                           :href "javascript:;"
+                                           :onClick #(swap! state assoc :show-import-overlay? true
+                                                      :selected-method (str msm))}
+                                       (str msm)])}
                  {:header "Synopsis" :starting-width 500 :sort-by :value}]
        :data (map (fn [m]
                     [(m "namespace")
                      (m "name")
                      (m "synopsis")])
-               (:methods props))}])})
+               (:methods props))}]))})
 
 
 (defn- create-mock-methods []

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
@@ -58,7 +58,7 @@
           :dismiss-self #(swap! state dissoc :show-import-overlay?)
           :content (importmc/render-import-overlay (:workspace-id props)
                      #(swap! state dissoc :show-import-overlay?)
-                     (:on-config-imported props))}])
+                     (:on-config-imported props) nil)}])
       [:div {:style {:float "right" :padding "0 2em 1em 0"}}
        [comps/Button {:text "Import Configuration ..."
                       :onClick #(swap! state assoc :show-import-overlay? true)}]]


### PR DESCRIPTION
This commit/PR is largely for modifying the user-facing UI.
If this PR is merged, then a next/todo PR/work is to further tweak
the "Import" window (which would be called the 
 "import and browse" window I guess) for browsing
 MCs and not just importing them.
Here "tweak" means additional logic so that the table won't display
MCs for any method except for those of the selected method.
It also means to *perhaps* modify the code so that the user can import an MC from
having entered the screen via the method-repo.
Additional tweak may be necessary in any event especially because AGORA is updating
the method-config schema
