### PR TITLE
Add delete workspace functionality

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -232,3 +232,36 @@
                      :height (:size props) :width (:size props)}}
       (style/center {}
         (icons/font-icon {:style {:color "#fff" :fontSize (:size props)}} :status-warning))])})
+
+(react/defc StatusLabel
+  {:render
+   (fn [{:keys [props]}]
+     [:div {:style {:background (:color props) :color "#fff"
+                    :padding 20 :borderRadius 5 :textAlign "center"}}
+      (:icon props)
+      [:span {:style {:marginLeft "1.5ex" :fontSize "125%" :fontWeight 400
+                      :verticalAlign "middle"}}
+       (:text props)]])})
+
+(react/defc SidebarButton
+  {:get-default-props
+   (fn []
+     {:style :heavy})
+   :render
+   (fn [{:keys [props]}]
+     (let [heavy? (= :heavy (:style props))
+           margin (:margin props)
+           color (if-not (keyword? (:color props))
+                   (:color props)
+                   (get style/colors (:color props)))]
+       [:div {:style {:fontSize "106%"
+                      :marginTop (when (= margin :top) "1em")
+                      :marginBottom (when (= margin :bottom) "1em")
+                      :padding "0.7em 0" :cursor "pointer" :textAlign "center"
+                      :backgroundColor (if heavy? color "transparent")
+                      :color (if heavy? "#fff" color)
+                      :border (when-not heavy? (str "1px solid " (:line-gray style/colors)))
+                      :borderRadius (when heavy? 4)}
+              :onClick (:onClick props)}
+        (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} (:icon props))
+        [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} (:text props)]]))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -67,15 +67,17 @@
                                :lastFailureDate (rand-nth [nil (utils/rand-recent-time)])}
     :owners ["test@broadinstitute.org"]}})
 
+(defn delete-workspace [workspace-id]
+  {:path (str "/workspaces/" (ws-path workspace-id))
+   :method :delete})
+
 (defn get-workspace-acl [workspace-id]
   {:path (str "/workspaces/" (ws-path workspace-id) "/acl")
    :method :get
    :mock-data
-   (map
-     (fn [i]
-       {:userId (str "user" i "@broadinstitute.org")
-        :accessLevel (rand-nth ["OWNER" "WRITER" "READER" "NO ACCESS" "UNKNOWN USER"])})
-     (range (rand-int 5)))})
+   {:acl (into {} (map (fn [i] [(str "user" i "@broadinstitute.org")
+                                (rand-nth ["OWNER" "WRITER" "READER" "NO ACCESS" "UNKNOWN USER"])])
+                    (range (inc (rand-int 5)))))}})
 
 (defn update-workspace-acl [workspace-id]
   {:path (str "/workspaces/" (ws-path workspace-id) "/acl")

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -16,7 +16,7 @@
       [comps/TabBar {:ref "tab-bar"
                      :items
                      [{:text "Summary"
-                       :render #(summary-tab/render (:workspace-id props))}
+                       :render #(summary-tab/render (:workspace-id props) (:on-delete props))}
                       {:text "Data" :render #(data-tab/render (:workspace-id props))}
                       {:text "Method Configurations"
                        :render (fn []
@@ -27,5 +27,5 @@
                       {:text "Files" :render (fn [] [:div {} "Not yet implemented."])}]}]])})
 
 
-(defn render-workspace-details [workspace-id]
-  (react/create-element WorkspaceDetails {:workspace-id workspace-id}))
+(defn render-workspace-details [workspace-id on-delete]
+  (react/create-element WorkspaceDetails {:workspace-id workspace-id :on-delete on-delete}))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
@@ -87,25 +87,18 @@
             (endpoints/call-ajax-orch
               {:endpoint (endpoints/delete-workspace-method-config (:workspace-id props) (:config props))
                :on-done (fn [{:keys [success? xhr]}]
-                          (swap! state assoc :deleting? false)
+                          (swap! state dissoc :deleting?)
                           (if success?
                             ((:on-rm props))
                             (js/alert (str "Error during deletion: " (.-statusText xhr)))))}))
    :render (fn [{:keys [this state]}]
-             (if (:deleting? @state)
-               [comps/Blocker
-                {:banner (str "Deleting...")}]
-               [:div {:style {:marginTop "1em"
-                              :padding "0.7em 0" :cursor "pointer"
-                              :backgroundColor "transparent" :color (:exception-red style/colors)
-                              :border (str "1px solid " (:line-gray style/colors))}
-                      :onClick (fn []
-                                 (let [confirmed? (js/confirm "Are you sure?")]
-                                   (when confirmed?
-                                     (do (swap! state assoc :deleting? true)
-                                         (react/call :rm-mc this)))))}
-                (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} :trash-can)
-                [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} "Delete"]]))})
+             (when (:deleting? @state)
+               [comps/Blocker {:banner (str "Deleting...")}])
+             [comps/SidebarButton {:style :light :color :exception-red :margin :top
+                                   :text "Delete" :icon :trash-can
+                                   :onClick #(when (js/confirm "Are you sure?")
+                                              (swap! state assoc :deleting? true)
+                                              (react/call :rm-mc this))}])})
 
 
 (defn- render-side-bar [state refs config editing? props]
@@ -114,35 +107,25 @@
    (style/create-unselectable :div {:style {:position (when-not (:sidebar-visible? @state) "fixed")
                                             :top (when-not (:sidebar-visible? @state) 4)
                                             :width 290}}
-     [:div {:style {:fontSize "106%" :lineHeight 1 :textAlign "center"}}
-
+     [:div {:style {:lineHeight 1}}
       (when-not editing?
-        [:div {:style {:padding "0.7em 0" :cursor "pointer"
-                       :backgroundColor "transparent" :color (:button-blue style/colors)
-                       :border (str "1px solid " (:line-gray style/colors))}
-               :onClick #(swap! state assoc :editing? true :prereqs-list (vals (config "prerequisites")))}
-         (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} :pencil)
-         [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} "Edit this page"]])
-
+        [comps/SidebarButton {:style :light :color :button-blue
+                              :text "Edit this page" :icon :pencil
+                              :onClick #(swap! state assoc :editing? true
+                                         :prereqs-list (vals (config "prerequisites")))}])
       (when-not editing?
         [DeleteButton
          {:workspace-id (:workspace-id props)
           :on-rm (:on-rm props)
           :config config}])
-
       (when editing?
-        [:div {:style {:padding "0.7em 0" :cursor "pointer"
-                       :backgroundColor (:success-green style/colors) :color "#fff" :borderRadius 4}
-               :onClick #(do (commit state refs config props) (stop-editing state refs))}
-         (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} :status-done)
-         [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} "Save"]])
-
+        [comps/SidebarButton {:color :success-green
+                              :text "Save" :icon :status-done
+                              :onClick #(do (commit state refs config props) (stop-editing state refs))}])
       (when editing?
-        [:div {:style {:padding "0.7em 0" :marginTop "0.5em" :cursor "pointer"
-                       :backgroundColor (:exception-red style/colors) :color "#fff" :borderRadius 4}
-               :onClick #(stop-editing state refs)}
-         (icons/font-icon {:style {:verticalAlign "middle" :fontSize "135%"}} :x)
-         [:span {:style {:verticalAlign "middle" :marginLeft "1em"}} "Cancel Editing"]])])])
+        [comps/SidebarButton {:color :exception-red :margin :top
+                              :text "Cancel Editing" :icon :x
+                              :onClick #(stop-editing state refs)}])])])
 
 
 (defn- render-main-display [state refs config editing?]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -9,6 +9,7 @@
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.nav :as nav]
     [org.broadinstitute.firecloud-ui.page.workspace.details :refer [render-workspace-details]]
+    [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
 
 
@@ -224,5 +225,6 @@
          [:span {:style {:fontSize "180%"}}
           (if selected-ws-id (:name selected-ws-id) "Workspaces")]]
         (if selected-ws-id
-          (render-workspace-details selected-ws-id)
+          ;; TODO: add 'back' function to nav
+          (render-workspace-details selected-ws-id #(set! (-> js/window .-location .-hash) "workspaces"))
           (render-workspaces-list nav-context))]))})


### PR DESCRIPTION
* Delete button now appears on summary tab if you have OWNER status.  After delete you get taken back to the workspaces list.
* Generalized the buttons and status labels that appear in the left column of several pages.
* Fixed an issue with ACL mock data