### PR TITLE
View and edit workspace attributes

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -33,6 +33,9 @@
          {:accessLevel (rand-nth ["OWNER" "WRITER" "READER"])
           :workspace {:namespace ns
                       :name (str "Workspace " (inc i))
+                      :attributes {"Attribute1" "[some value]"
+                                   "Attribute2" "[some value]"
+                                   "Attribute3" "[some value]"}
                       :status status
                       :createdBy ns
                       :createdDate (utils/rand-recent-time)}
@@ -61,6 +64,9 @@
    {:accessLevel "OWNER"
     :workspace {:namespace (:namespace workspace-id)
                 :name (:name workspace-id)
+                :attributes {"Attribute1" "[some value]"
+                             "Attribute2" "[some value]"
+                             "Attribute3" "[some value]"}
                 :status (rand-nth ["Complete" "Running" "Exception"])
                 :createdBy (:namespace workspace-id)
                 :createdDate (.toISOString (js/Date.))}
@@ -137,6 +143,10 @@
   {:path (str "/workspaces/" (ws-path workspace-id)
            "/method_configs/" (config "namespace") "/" (config "name"))
    :method :delete})
+
+(defn update-workspace-attrs [workspace-id]
+  {:path (str "/workspaces/" (ws-path workspace-id) "/updateAttributes")
+   :method :patch})
 
 (defn import-entities [workspace-id]
   {:path (str "/workspaces/" (ws-path workspace-id) "/importEntities")


### PR DESCRIPTION
This is the UI work associated with [DSDEEPB-1137](https://broadinstitute.atlassian.net/browse/DSDEEPB-1137) and firecloud-orchestration [PR #77](https://github.com/broadinstitute/firecloud-orchestration/pull/77).

This is functionally complete and ready for review- you can view/edit/add/delete attributes on workspaces.

I'd like some feedback on how to solve the following problems:

~~A small bug that doesn't really come up often:
1) Delete an attribute that already exists (i.e. “Attribute1”)
2) Add new row, and put “Attribute1” into name field
3) Add new row again, and the field with "Attribute1" in it becomes un-editable 
4) Right now, If the user does need to edit it after encountering this, they can just delete that row and enter that info again and it will be fine~~

~~Another bug which is more of an annoyance rather than a problem:
Adding more than 9 rows causes the new rows to spawn in seemingly random locations. I'm assuming that this has to do with the fact that I'm using a map for my attribute data, and the docs seem to say that when adding pairs to a map, they aren't appended at the end but rather added anywhere within the map. Any suggestions?~~