### PR TITLE
DSDEEPB-32: add mailto: link for Support footer

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
@@ -27,6 +27,7 @@
               {:render
                (fn [{:keys [props state]}]
                  [:a {:href (:href props)
+                      :target (:target props)
                       :style {:color (:footer-text style/colors)
                               :textDecoration (when-not (:hovering? @state) "none")}
                       :onMouseOver #(swap! state assoc :hovering? true)
@@ -39,11 +40,11 @@
      [:div {:style {:display "block"}}
       (str "\u00A9 " yeartext " Broad Institute")
       spacer
-      [Link {:href "#" :text "Privacy Policy"}]
+      [Link {:href "#" :text "Privacy Policy" :target "_self"}]
       spacer
-      [Link {:href "#" :text "Terms of Service"}]
+      [Link {:href "#" :text "Terms of Service" :target "_self"}]
       spacer
-      [Link {:href "#" :text "Support"}]]]))
+      [Link {:href "mailto:firecloud-help@broadinstitute.org?Subject=FireCloud%20Help" :text "Support" :target "_blank"}]]]))
 
 
 (def top-nav-bar-items


### PR DESCRIPTION
Support link in the footer is now a mailto: to firecloud-help@broadinstitute.org, a newly-created Google Group.

Note that the mailto: link WILL ONLY WORK IF YOUR CHROME IS CONFIGURED WITH AN EMAIL HANDLER. See https://support.google.com/chrome/answer/1382847?hl=en. Try loading gmail, looking for the handler icon, and clicking on it.

I realize this restriction may not be tenable for the long term, but that's the MVP scope for this story, so I'm pushing it through.

We can edit members, permission, etc. of the Google Group in the future.