### PR TITLE
Table cleanup and auditing of uses

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -146,7 +146,9 @@
             :onResizeMouseDown onResizeMouseDown
             :onResizeDoubleClick #(swap! state update-in [:ordered-columns display-index]
                                      assoc :width (:starting-width column))
-            :onSortClick (when-let [sorter (:sort-by column)]
+            :onSortClick (when (and (or (:sort-by column)
+                                        (:sortable-columns? props))
+                                    (not= :none (:sort-by column)))
                            (fn [e]
                              (if (= i (:sort-column @state))
                                (case (:sort-order @state)
@@ -154,9 +156,9 @@
                                  :desc (swap! state dissoc :sort-column :sort-order :key-fn)
                                  (assert false "bad state"))
                                (swap! state assoc :sort-column i :sort-order :asc
-                                 :key-fn (if (= :value sorter)
-                                           (fn [row] (str (nth row i)))
-                                           (fn [row] (sorter (nth row i))))))
+                                 :key-fn (if-let [sorter (:sort-by column)]
+                                           (fn [row] (sorter (nth row i)))
+                                           (fn [row] (nth row i)))))
                              (react/call :set-body-rows this)))
             :sortOrder (when (= i (:sort-column @state)) (:sort-order @state))})))
      (filter :showing? (:ordered-columns @state)))
@@ -317,6 +319,7 @@
       :paginator-space 24
       :resizable-columns? true
       :reorderable-columns? true
+      :sortable-columns? true
       :filterable? true
       :empty-message "There are no rows to display."})
    :get-initial-state

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -311,6 +311,56 @@
         columns)))
 
 
+;; Table component with specifiable style and column behaviors.
+;;
+;; Properties:
+;;   :cell-padding-left (optional, default 16px)
+;;     A CSS padding-left value to apply to each cell
+;;   :paginator (optional, default :below)
+;;     Either :above or :below, determines where the paginator appears relative to the table
+;;   :paginator-space (optional, default 24)
+;;     A CSS padding value used to separate the table and paginator.
+;;   :resizable-columns? (optional, default true)
+;;     Fallback value for column resizing.
+;;   :reorderable-columns? (optional, default true)
+;;     Controls whether or not columns are reorderable.  When true, a reorder widget is presented
+;;   :sortable-columns? (optional, default true)
+;;     Fallback value for column sorting.
+;;   :filterable? (optional, default true)
+;;     Controls whether or not columns are filterable.  When true, a filter widget is presented
+;;   :empty-message (optional, default "There are no rows to display.")
+;;     A banner to display when the table is empty
+;;   :row-style (optional)
+;;     Style to apply to each row.  Properties overridden by :even-row-style and :odd-row-style.
+;;     When row styling is omitted, default properties create alternating white and gray backgrounds
+;;   :even-row-style (optional)
+;;     Style to apply to even-numbered rows.  Properties override :row-style
+;;   :odd-row-style (optional)
+;;     Style to apply to odd-numbered-rows.  Properties override :row-style
+;;   :header-row-style (optional)
+;;     Style to apply to the header row.  When omitted, style is a dark gray background with bold white text
+;;   :columns (REQUIRED)
+;;     A sequence of column maps.  The order given is used as the initial order.
+;;     Columns have the following properties:
+;;       :header (optional, default none)
+;;         The text to display.
+;;       :starting-width (optional, default 100)
+;;         The initial width, which may be resized
+;;       :content-renderer (optional)
+;;         A function from the column value to a displayable representation.  If omitted, a
+;;         default renderer is used which displays a reasonable string for most types
+;;       :resizable? (optional)
+;;         Controls if the column is resizable.  If absent, falls back to the table.
+;;       :filter-by (optional, defaults to 'str')
+;;         A function from the column value to a string to use for matching filter text.
+;;         Use ':filter-by :none' to disable filtering a specific column of an otherwise filterable table.
+;;       :sort-by (optional)
+;;         A function from the column value to a sortable type.  If present, the column is made
+;;         sortable.  If omitted, the :sortable-columns? top-level property is checked to see if
+;;         the column should be sortable, and if so, the column is sorted by the column type directly.
+;;         Use ':sort-by :none' to disable sorting a specific column of an otherwise sortable table.
+;;   :data (REQUIRED)
+;;     A sequence-of-sequences forming the data grid.
 (react/defc Table
   {:get-default-props
    (fn []

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -191,10 +191,10 @@
             [:div {:style row-style}
              (map
                (fn [col]
-                 (let [render-content (or (:content-renderer col) (fn [i data] (default-render data)))]
+                 (let [render-content (or (:content-renderer col) (fn [data] (default-render data)))]
                    (render-cell
                      {:width (:width col)
-                      :content (render-content row-index (nth row (:index col)))
+                      :content (render-content (nth row (:index col)))
                       :cell-padding-left (or (:cell-padding-left props) 0)
                       :content-container-style (merge
                                                  {:padding (str "0.6em 0 0.6em " (or (:cell-padding-left props) 0))}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
@@ -37,7 +37,7 @@
                   :sort-by  #(get-ordered-id-fields %)
                   :filter-by #(clojure.string/join ":" (get-ordered-id-fields %))
                   :content-renderer
-                  (fn [row method]
+                  (fn [method]
                     [:a {:style {:color (:button-blue style/colors) :textDecoration "none"}
                          :href "javascript:;"
                          :onClick (fn []
@@ -47,8 +47,7 @@
                                       :show-import-overlay? true))}
                      (clojure.string/join ":" (get-ordered-id-fields method))])}
                  {:header "Method Synopsis"
-                  :content-renderer (fn [row method]
-                                      (get-in method ["method" "synopsis"]))
+                  :content-renderer #(get-in % ["method" "synopsis"])
                   :starting-width 150 :sort-by :value }
                  {:header "Configuration Name" :starting-width 150 :sort-by :value}
                  {:header "Namespace" :starting-width 150 :sort-by :value}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
@@ -46,16 +46,14 @@
                                       :selected-config method
                                       :show-import-overlay? true))}
                      (clojure.string/join ":" (get-ordered-id-fields method))])}
-                 {:header "Method Synopsis"
-                  :content-renderer #(get-in % ["method" "synopsis"])
-                  :starting-width 150 :sort-by :value }
-                 {:header "Configuration Name" :starting-width 150 :sort-by :value}
-                 {:header "Namespace" :starting-width 150 :sort-by :value}
-                 {:header "Snapshot ID" :starting-width 150 :sort-by :value  }
-                 {:header "Synopsis" :starting-width 500 :sort-by :value}]
+                 {:header "Method Synopsis" :starting-width 150}
+                 {:header "Configuration Name" :starting-width 150}
+                 {:header "Namespace" :starting-width 150}
+                 {:header "Snapshot ID" :starting-width 150}
+                 {:header "Synopsis" :starting-width 400}]
        :data (map (fn [m]
                       [m
-                       m
+                       (get-in m ["method" "synopsis"])
                        (m "name")
                        (m "namespace")
                        (m "snapshotId")

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data_tab.cljs
@@ -30,9 +30,9 @@
          {:key (:entity-type @state)
           :empty-message "There are no entities to display."
           :columns (concat
-                     [{:header "Entity Type" :starting-width 100 :sort-by :value}
-                      {:header "Entity Name" :starting-width 100 :sort-by :value}]
-                     (map (fn [k] {:header k :starting-width 100 :sort-by :value}) attribute-keys))
+                     [{:header "Entity Type" :starting-width 100}
+                      {:header "Entity Name" :starting-width 100}]
+                     (map (fn [k] {:header k :starting-width 100}) attribute-keys))
           :data (map (fn [m]
                        (concat
                          [(m "entityType")

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/launch_analysis.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/launch_analysis.cljs
@@ -58,7 +58,7 @@
       :empty-message "No entities available."
       :columns (concat
                 [{:header "" :starting-width 40 :resizable? false :reorderable? false
-                  :content-renderer (fn [i data]
+                  :content-renderer (fn [data]
                                       [:input {:type "radio"
                                                :checked (identical? data selected-entity)
                                                :onChange #(on-entity-selected data)}])}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/launch_analysis.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/launch_analysis.cljs
@@ -58,13 +58,14 @@
       :empty-message "No entities available."
       :columns (concat
                 [{:header "" :starting-width 40 :resizable? false :reorderable? false
+                  :sort-by :none :filter-by :none
                   :content-renderer (fn [data]
                                       [:input {:type "radio"
                                                :checked (identical? data selected-entity)
                                                :onChange #(on-entity-selected data)}])}
-                 {:header "Entity Type" :starting-width 100 :sort-by :value}
-                 {:header "Entity Name" :starting-width 100 :sort-by :value}]
-                (map (fn [k] {:header k :starting-width 100 :sort-by :value}) attribute-keys))
+                 {:header "Entity Type" :starting-width 100}
+                 {:header "Entity Name" :starting-width 100}]
+                (map (fn [k] {:header k :starting-width 100}) attribute-keys))
       :data (map (fn [m]
                    (concat
                     [m

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
@@ -126,11 +126,11 @@
                             :onClick #(on-config-selected conf)
                             :style {:color (:button-blue style/colors) :textDecoration "none"}}
                         (conf "name")])}
-                    {:header "Namespace" :starting-width 200 :sort-by :value}
-                    {:header "Snapshot Id" :starting-width 100 :sort-by :value}
-                    {:header "Synopsis" :starting-width 160 :sort-by :value}
-                    {:header "Create Date" :starting-width 210 :sort-by :value}
-                    {:header "Owner" :starting-width 290 :sort-by :value}]
+                    {:header "Namespace" :starting-width 200}
+                    {:header "Snapshot Id" :starting-width 100}
+                    {:header "Synopsis" :starting-width 160}
+                    {:header "Create Date" :starting-width 210}
+                    {:header "Owner" :starting-width 290}]
           :data (map
                   (fn [config]
                     [config

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_importer.cljs
@@ -121,7 +121,7 @@
          {:empty-message "There are no method configurations available"
           :columns [{:header "Name" :starting-width 200 :filter-by #(% "name") :sort-by #(% "name")
                      :content-renderer
-                     (fn [row-index conf]
+                     (fn [conf]
                        [:a {:href "javascript:;"
                             :onClick #(on-config-selected conf)
                             :style {:color (:button-blue style/colors) :textDecoration "none"}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
@@ -55,15 +55,15 @@
                      :style {:color (:button-blue style/colors) :textDecoration "none"}
                      :onClick #((:on-config-selected props) config)}
                  (config "name")])}
-             {:header "Namespace" :starting-width 200 :sort-by :value}
-             {:header "Root Entity Type" :starting-width 140 :sort-by :value}
-             {:header "Method Store Method" :starting-width 300
+             {:header "Namespace" :starting-width 200}
+             {:header "Root Entity Type" :starting-width 140}
+             {:header "Method Store Method" :starting-width 300 :sort-by :none
               :filter-by #(str (% "methodNamespace") (% "methodName") (% "methodVersion"))
               :content-renderer
               #(render-map %
                 ["methodNamespace" "methodName" "methodVersion"]
                 ["Namespace" "Name" "Version"])}
-             {:header "Method Store Configuration" :starting-width 300
+             {:header "Method Store Configuration" :starting-width 300  :sort-by :none
               :filter-by #(str (% "methodConfigNamespace") (% "methodConfigName") (% "methodConfigVersion"))
               :content-renderer
               #(render-map %

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
@@ -50,7 +50,7 @@
             :columns
             [{:header "Name" :starting-width 240 :sort-by #(% "name") :filter-by #(% "name")
               :content-renderer
-              (fn [row-index config]
+              (fn [config]
                 [:a {:href "javascript:;"
                      :style {:color (:button-blue style/colors) :textDecoration "none"}
                      :onClick #((:on-config-selected props) config)}
@@ -60,17 +60,15 @@
              {:header "Method Store Method" :starting-width 300
               :filter-by #(str (% "methodNamespace") (% "methodName") (% "methodVersion"))
               :content-renderer
-              (fn [row-index msm]
-                (render-map msm
-                  ["methodNamespace" "methodName" "methodVersion"]
-                  ["Namespace" "Name" "Version"]))}
+              #(render-map %
+                ["methodNamespace" "methodName" "methodVersion"]
+                ["Namespace" "Name" "Version"])}
              {:header "Method Store Configuration" :starting-width 300
               :filter-by #(str (% "methodConfigNamespace") (% "methodConfigName") (% "methodConfigVersion"))
               :content-renderer
-              (fn [row-index msc]
-                (render-map msc
-                  ["methodConfigNamespace" "methodConfigName" "methodConfigVersion"]
-                  ["Namespace" "Name" "Version"]))}]
+              #(render-map %
+                ["methodConfigNamespace" "methodConfigName" "methodConfigVersion"]
+                ["Namespace" "Name" "Version"])}]
             :data (map
                     (fn [config]
                       [config

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor_tab.cljs
@@ -16,7 +16,7 @@
     :columns
     [{:header "Date" :starting-width 200
       :sort-by #(% "submissionDate") :filter-by #(% "submissionDate")
-      :content-renderer (fn [row-index submission]
+      :content-renderer (fn [submission]
                           [:a {:href "javascript:;"
                                :style {:color (:button-blue style/colors) :textDecoration "none"}
                                :onClick #(on-submission-clicked (submission "submissionId"))}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor_tab.cljs
@@ -21,9 +21,9 @@
                                :style {:color (:button-blue style/colors) :textDecoration "none"}
                                :onClick #(on-submission-clicked (submission "submissionId"))}
                            (.format (js/moment (submission "submissionDate")) "LLL")])}
-     {:header "Status" :sort-by :value}
-     {:header "Method Configuration" :starting-width 220 :sort-by :value}
-     {:header "Data Entity" :starting-width 220 :sort-by :value}]
+     {:header "Status"}
+     {:header "Method Configuration" :starting-width 220}
+     {:header "Data Entity" :starting-width 220}]
     :data (map (fn [x]
                  [x
                   (x "status")

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/submission_details.cljs
@@ -68,12 +68,12 @@
       [table/Table
        {:key (:active-filter @state)
         :empty-message "No Workflows"
-        :columns [{:header "Data Entity" :starting-width 200 :sort-by :value}
-                  {:header "Last Changed" :starting-width 280 :sort-by :value
+        :columns [{:header "Data Entity" :starting-width 200}
+                  {:header "Last Changed" :starting-width 280
                    :content-renderer #(let [m (js/moment %)]
                                        (str (.format m "L [at] LTS") " ("
                                          (.fromNow m) ")"))}
-                  {:header "Status" :starting-width 120 :sort-by :value
+                  {:header "Status" :starting-width 120
                    :content-renderer (fn [status]
                                        [:div {}
                                         (icon-for-wf-status status)
@@ -84,7 +84,7 @@
                                         (map (fn [message]
                                                [:div {} message])
                                           message-list)])}
-                  {:header "Workflow ID" :starting-width 300 :sort-by :value}]
+                  {:header "Workflow ID" :starting-width 300}]
         :data (map (fn [row]
                      [(str (get-in row ["workflowEntity" "entityName"]) " ("
                         (get-in row ["workflowEntity" "entityType"]) ")")
@@ -100,7 +100,7 @@
    (fn [{:keys [props]}]
      [table/Table
       {:empty-message "No Workflows"
-       :columns [{:header "Data Entity" :starting-width 200 :sort-by :value
+       :columns [{:header "Data Entity" :starting-width 200 :sort-by (juxt :type :name)
                   :filter-by (fn [entity]
                                (str (:type entity) " " (:name entity)))
                   :content-renderer (fn [entity]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/submission_details.cljs
@@ -70,17 +70,16 @@
         :empty-message "No Workflows"
         :columns [{:header "Data Entity" :starting-width 200 :sort-by :value}
                   {:header "Last Changed" :starting-width 280 :sort-by :value
-                   :content-renderer (fn [row-index date]
-                                       (let [m (js/moment date)]
-                                         (str (.format m "L [at] LTS") " ("
-                                           (.fromNow m) ")")))}
+                   :content-renderer #(let [m (js/moment %)]
+                                       (str (.format m "L [at] LTS") " ("
+                                         (.fromNow m) ")"))}
                   {:header "Status" :starting-width 120 :sort-by :value
-                   :content-renderer (fn [row-index status]
+                   :content-renderer (fn [status]
                                        [:div {}
                                         (icon-for-wf-status status)
                                         status])}
                   {:header "Messages" :starting-width 300 :sort-by count
-                   :content-renderer (fn [row-index message-list]
+                   :content-renderer (fn [message-list]
                                        [:div {}
                                         (map (fn [message]
                                                [:div {} message])
@@ -104,10 +103,10 @@
        :columns [{:header "Data Entity" :starting-width 200 :sort-by :value
                   :filter-by (fn [entity]
                                (str (:type entity) " " (:name entity)))
-                  :content-renderer (fn [i entity]
+                  :content-renderer (fn [entity]
                                       (str (:name entity) " (" (:type entity) ")"))}
                  {:header "Errors" :starting-width 500 :sort-by count
-                  :content-renderer (fn [i error-list]
+                  :content-renderer (fn [error-list]
                                       [:div {}
                                        (map (fn [error]
                                               [:div {} error])

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/submission_details.cljs
@@ -49,6 +49,10 @@
               (contains? #{"Failed" "Aborted" "Unknown"} (wf "status"))))
     wfs))
 
+(defn- render-date [date]
+  (let [m (js/moment date)]
+    (str (.format m "L [at] LTS") " (" (.fromNow m) ")")))
+
 (react/defc WorkflowsTable
   {:get-initial-state
    (fn []
@@ -70,15 +74,13 @@
         :empty-message "No Workflows"
         :columns [{:header "Data Entity" :starting-width 200}
                   {:header "Last Changed" :starting-width 280
-                   :content-renderer #(let [m (js/moment %)]
-                                       (str (.format m "L [at] LTS") " ("
-                                         (.fromNow m) ")"))}
+                   :content-renderer render-date :filter-by render-date}
                   {:header "Status" :starting-width 120
                    :content-renderer (fn [status]
                                        [:div {}
                                         (icon-for-wf-status status)
                                         status])}
-                  {:header "Messages" :starting-width 300 :sort-by count
+                  {:header "Messages" :starting-width 300
                    :content-renderer (fn [message-list]
                                        [:div {}
                                         (map (fn [message]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -113,7 +113,7 @@
       :header-row-style {:fontWeight nil :fontSize "90%"
                          :color (:text-light style/colors) :backgroundColor nil}
       :header-style {:padding "0 0 1em 14px" :overflow nil}
-      :resizable-columns? false :reorderable-columns? false
+      :resizable-columns? false :reorderable-columns? false :sortable-columns? false
       :body-style {:fontSize nil :fontWeight nil
                    :borderLeft border-style :borderRight border-style
                    :borderBottom border-style :borderRadius 4}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -9,7 +9,6 @@
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.nav :as nav]
     [org.broadinstitute.firecloud-ui.page.workspace.details :refer [render-workspace-details]]
-    [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
 
 
@@ -123,15 +122,13 @@
       :cell-content-style {:padding nil}
       :columns
       [{:header [:div {:style {:marginLeft -6}} "Status"] :starting-width 60
-        :content-renderer (fn [row-index data]
-                            [StatusCell {:data data}])
+        :content-renderer (fn [data] [StatusCell {:data data}])
         :filter-by :none}
        {:header "Workspace" :starting-width 250
-        :content-renderer (fn [row-index data]
-                            [WorkspaceCell {:data data}])
+        :content-renderer (fn [data] [WorkspaceCell {:data data}])
         :filter-by :name}
        {:header "Description" :starting-width 400
-        :content-renderer (fn [row-index data]
+        :content-renderer (fn [data]
                             [:div {:style {:padding "1.1em 0 0 14px"}}
                              "No data available."])
         :filter-by :none}]


### PR DESCRIPTION
* Added some "API documentation" to the table component as it's gotten a bit complicated
* Changed defaults so that columns sort by default, which can be disabled at the table level or on a column via `:sort-by :none`
* Removed row index as a parameter from `:content-renderer`, since it was never used
* Fixed some logic in `submission-details`