### PR TITLE
include workspace id when renaming a config

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_config_editor.cljs
@@ -47,7 +47,8 @@
                    "name" name
                    "inputs" inputs
                    "outputs" outputs
-                   "prerequisites" prereqs)]
+                   "prerequisites" prereqs
+                   "workspaceName" workspace-id)]
     (swap! state assoc :blocker "Updating...")
     (endpoints/call-ajax-orch
       {:endpoint (endpoints/update-workspace-method-config workspace-id config)


### PR DESCRIPTION
After closer inspection, our edit-config functionality (within a workspace) DID have a bug ... but the bug wasn't caused by the change in rawls' save-config API. We were simply failing to include the right info in our payload. This PR changes that.