### PR TITLE
Cleanup of method import/export code

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -31,6 +31,13 @@
 
 (defn scroll-to-top [] (scroll-to 0 0))
 
+(defn scroll-to-center [elem]
+  (let [elem-center-x (+ (.-offsetLeft elem) (/ (.-offsetWidth elem) 2))
+        elem-center-y (+ (.-offsetTop elem) (/ (.-offsetHeight elem) 2))]
+    (scroll-to
+      (- elem-center-x (/ (.-innerWidth js/window) 2))
+      (- elem-center-y (/ (.-innerHeight js/window) 2)))))
+
 (defn is-in-view [elem]
   (let [doc-view-top (.-scrollY js/window)
         doc-view-bottom (+ doc-view-top (.-innerHeight js/window))

--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -277,6 +277,21 @@
         :entityType (rand-nth ["Task" "Workflow"])})
      (range (rand-int 100)))})
 
+;; I would have called it "get-method" but that's already defined in core
+(defn get-agora-method [namespace name snapshot-id]
+  {:path (str "/methods/" namespace "/" name "/" snapshot-id)
+   :method :get
+   :mock-data
+   {:namespace namespace
+    :name name
+    :snapshotId snapshot-id
+    :synopsis (rand-nth ["variant caller synopsis", "gene analyzer synopsis", "mutect synopsis"])
+    :documentation (str "Documentation for method")
+    :createDate (utils/rand-recent-time)
+    :url "http://agora.broadinstitute.org/methods/someurl"
+    :payload "task wc {File in_file command { cat ${in_file} | wc -l } output { Int count = read_int(stdout()) }}\n"
+    :entityType (rand-nth ["Task" "Workflow"])}})
+
 
 (def list-configurations
   {:path "/configurations"

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/methods_configs_acl.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/methods_configs_acl.cljs
@@ -69,6 +69,7 @@
      [comps/Dialog
       {:width "75%"
        :blocking? true
+       :dismiss-self (:dismiss-self props)
        :content (react/create-element
                   [:div {:style {:background "#fff" :padding "2em"}}
                    (cond


### PR DESCRIPTION
Not 100% generalized, but since dealing with methods and configs involves different API calls this is about as far as it can go before it gets impossible to read.

* Created a method/config detail viewer that will hopefully be used for the method config editor later.  It operates on a fully loaded method/config from an Agora call.
* Added scroll-to-center utility for making sure the error message is visible.  It would be nice to add smooth scrolling in the future.
* Generalized the import form side of things to reduce code duplication
* Moved loading the workspaces to the import form