### PR TITLE
Es dsdeepb 1418

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -462,13 +462,9 @@
 (defn get-agora-method-acl [ns n sid is-conf]
   {:path (str "/" (if is-conf "configurations" "methods"  ) "/" ns "/" n "/" sid "/permissions"  )
    :method :get
-   :mock-data
-   (map (fn [i] {(str "user" ) (str "user" i)
-                 (str "roles") (rand-nth
-                                 [["Read"]
-                                  ["Read" "Write" "Create" "Redact" "Manage"]
-                                  []])})
-     (range (inc (rand-int 5))))})
+   :mock-data (map (fn [i] {:user (str "user" i "@broadinstitute.org")
+                           :accessLevel (rand-nth ["READER" "OWNER" "NO ACCESS"])})
+                (range (inc (rand-int 5))))})
 
 
 (defn persist-agora-method-acl [ent]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/methods_configs_acl.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/methods_configs_acl.cljs
@@ -17,49 +17,8 @@
      (entity "name")
      (entity "snapshotId")]))
 
-(defn- is-conf? [e]
-  (contains? e "method"))
-
 (def ^:private access-levels
   ["READER" "OWNER" "NO ACCESS"])
-
-(defn- build-acl-vec [acl-map]
-  (mapv
-    (fn [k] {:userId k :accessLevel (acl-map k)})
-    (keys acl-map)))
-
-
-(defn- ui-acl-to-agora-perms [ui-acl-str]
-  (cond
-    (= "NO ACCESS" ui-acl-str) [] ; empty array for no access
-    (= "READER" ui-acl-str) ["Read"] ; just reader
-    (= "OWNER" ui-acl-str) ["Read" "Write" "Create" "Redact" "Manage"])) ; all 5 perms
-
-(defn- translate-single-acl-map [a-map]
-  (let [ui-role (a-map :accessLevel)
-        agora-arr (ui-acl-to-agora-perms ui-role)
-        new-map (merge a-map {:accessLevel agora-arr})]
-    (utils/rlog (str "the ui-role is " ui-role))
-        new-map))
-
-(defn- agora-perms-to-ui-acl [agora_perm_arr]
-  (let [get-user (fn [e] (e "user"))
-        get-roles (fn [e] (e "roles"))
-        map-role-arr-to-ui-role (fn [role-arr]
-                    (cond
-                      (= 0 (count role-arr))
-                      "NO ACCESS" ; no entries maps to "NO ACCESS"
-                      (and (= 1 (count role-arr)) (= "Read" (nth role-arr 0)))
-                      "READER" ;exactly one entriy 'Read' maps to "READER"
-                      (= 5 (count role-arr))
-                      "OWNER" ; 5 entries maps to "OWNER"
-                      :else "READER"))
-        mapping-func (fn [perm-item]
-                       (let [user (get-user perm-item)
-                             roles (get-roles perm-item)
-                             ui-role (map-role-arr-to-ui-role roles)]
-                         {user ui-role}))]
-    (map mapping-func agora_perm_arr)))
 
 (def ^:private column-width "calc(50% - 4px)")
 
@@ -99,19 +58,19 @@
                                                          (:background-gray style/colors))}
                               :disabled (< i (:count-orig @state))
                               :spellCheck false
-                              :defaultValue (:userId acl-entry)})
+                              :defaultValue (acl-entry "user")})
                            (style/create-select
                              {:ref (str "acl-value" i)
                               :style {:float "right" :width column-width :height 33}
-                              :defaultValue (:accessLevel acl-entry)}
+                              :defaultValue (acl-entry "accessLevel")}
                              access-levels)
                            (common/clear-both)])
                         (:acl-vec @state))
-                      [comps/Button {:text "Add new" :style :add
-                                     :onClick #(swap! state assoc :acl-vec
-                                                (conj
-                                                  (react/call :capture-ui-state this)
-                                                  {:userId "" :accessLevel "READER"}))}]
+                      [comps/Button
+                       {:text "Add new" :style :add
+                        :onClick #(swap! state assoc
+                                   :acl-vec (flatten [(:acl-vec @state)
+                                                      {"user" "" "accessLevel" "READER"}]))}]
                       [:div {:style {:textAlign "center" :marginTop "1em"}}
                        [:a {:href "javascript:;"
                             :style {:textDecoration "none"
@@ -138,19 +97,17 @@
                       nmsp name sid (:is-conf props)))
         :on-done (fn [{:keys [success? get-parsed-response status-text]}]
                    (if success?
-                     (let [ui-maps (agora-perms-to-ui-acl (get-parsed-response))
-                           acl-vec (build-acl-vec (reduce merge ui-maps))]
+                     (let [acl-vec (get-parsed-response)]
                        (swap! state assoc :acl-vec acl-vec :count-orig (count acl-vec)))
                      (swap! state assoc :error status-text)))}))
    :persist-acl
    (fn [{:keys [props state this]}]
      (swap! state assoc :saving? true)
-     (swap! state assoc :acl-vec (map translate-single-acl-map
-                                   (react/call :capture-ui-state this)))
+     (swap! state assoc :acl-vec (react/call :capture-ui-state this))
      (endpoints/call-ajax-orch
        {:endpoint (endpoints/persist-agora-method-acl (:selected-entity props))
         :headers {"Content-Type" "application/json"}
-        :payload (filter #(not (empty? (:userId %))) (:acl-vec @state))
+        :payload (filterv #(not (empty? (:user %))) (:acl-vec @state))
         :on-done (fn [{:keys [success? status-text]}]
                    (swap! state dissoc :saving?)
                    (if success?
@@ -160,6 +117,6 @@
    (fn [{:keys [state refs]}]
      (mapv
        (fn [i]
-         {:userId (-> (@refs (str "acl-key" i)) .getDOMNode .-value trim)
+         {:user (-> (@refs (str "acl-key" i)) .getDOMNode .-value trim)
           :accessLevel (-> (@refs (str "acl-value" i)) .getDOMNode .-value)})
        (range (count (:acl-vec @state)))))})


### PR DESCRIPTION
This only displays mock data.
It cannot read data that is sent from either the Orchestration or from Agora.  This is by design.
The orchestration layer needs to act as a translator that speaks "UI-ese" and "Agora-ese" to translate between the two so that "OWNER" in UI-ese is "[Read,Write,Create,Redact,Manage]" in Agora-ese, "READER" is just "Read" in Agora-ese and "NO ACCESS" is "[]" (an empty array) in Agora-ese.
The purpose of this PR is to make sure that the only translation was done in the orch. and that no translation is done in the UI