### PR TITLE
Added :as-text property to table columns.

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -319,7 +319,7 @@
   (let [format-date #(.format (js/moment %) (or (:format props) "LLL"))]
     {:header (or (:header props) "Create Date")
      :starting-width (or (:starting-width props) 200)
-     :content-renderer format-date :filter-by format-date}))
+     :as-text format-date}))
 
 
 ;; Table component with specifiable style and column behaviors.

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -156,9 +156,10 @@
                                  :desc (swap! state dissoc :sort-column :sort-order :key-fn)
                                  (assert false "bad state"))
                                (swap! state assoc :sort-column i :sort-order :asc
-                                 :key-fn (if-let [sorter (:sort-by column)]
-                                           (fn [row] (sorter (nth row i)))
-                                           (fn [row] (nth row i)))))
+                                 :key-fn (let [sort-fn (or (:sort-by column) identity)]
+                                           (if (= sort-fn :text)
+                                             (fn [row] ((:as-text column) (nth row i)))
+                                             (fn [row] (sort-fn (nth row i)))))))
                              (react/call :set-body-rows this)))
             :sortOrder (when (= i (:sort-column @state)) (:sort-order @state))})))
      (filter :showing? (:ordered-columns @state)))
@@ -193,7 +194,9 @@
             [:div {:style row-style}
              (map
                (fn [col]
-                 (let [render-content (or (:content-renderer col) (fn [data] (default-render data)))]
+                 (let [render-content (or (:content-renderer col)
+                                          (:as-text col)
+                                          default-render)]
                    (render-cell
                      {:width (:width col)
                       :content (render-content (nth row (:index col)))
@@ -293,9 +296,10 @@
               (utils/matches-filter-text
                (apply str (map-indexed
                            (fn [i column]
-                             (if-let [f (:filter-by column)]
-                               (if (= f :none) "" (f (nth row i)))
-                               (str (nth row i))))
+                             (let [func (or (:filter-by column)
+                                            (:as-text column)
+                                            str)]
+                               (if (= func :none) "" (func (nth row i)))))
                            columns))
                filter-text))
             data)))
@@ -353,18 +357,22 @@
 ;;         The text to display.
 ;;       :starting-width (optional, default 100)
 ;;         The initial width, which may be resized
+;;       :as-text (optional)
+;;         A function from the column value to a one-line text representation.  Used as a fallback for
+;;         rendering, filtering, and sorting, and TODO: will be used for exporting tables
 ;;       :content-renderer (optional)
-;;         A function from the column value to a displayable representation.  If omitted, a
-;;         default renderer is used which displays a reasonable string for most types
+;;         A function from the column value to a displayable representation.  If omitted, :as-text is used.
+;;         If :as-text is also omitted, a default renderer is used.
 ;;       :resizable? (optional)
 ;;         Controls if the column is resizable.  If absent, falls back to the table.
-;;       :filter-by (optional, defaults to 'str')
+;;       :filter-by (optional, defaults to :as-text and then to 'str')
 ;;         A function from the column value to a string to use for matching filter text.
 ;;         Use ':filter-by :none' to disable filtering a specific column of an otherwise filterable table.
 ;;       :sort-by (optional)
 ;;         A function from the column value to a sortable type.  If present, the column is made
 ;;         sortable.  If omitted, the :sortable-columns? top-level property is checked to see if
 ;;         the column should be sortable, and if so, the column is sorted by the column type directly.
+;;         Use ':sort-by :text' to sort on the value returned by :as-text.
 ;;         Use ':sort-by :none' to disable sorting a specific column of an otherwise sortable table.
 ;;       :sort-initial (optional)
 ;;         A flag to set the initial column to sort.  Value is either :asc or :desc.  If present on multiple

--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -114,9 +114,9 @@
        {:name (str "Configuration " (inc i))
         :namespace (rand-nth ["Broad" "nci" "public"])
         :rootEntityType "Task"
-        :methodStoreMethod {:methodNamespace (str "ms_ns_" (inc i))
-                            :methodName (str "ms_n_" (inc i))
-                            :methodVersion (str "ms_v_" (inc i))}
+        :methodRepoMethod {:methodNamespace (rand-nth ["Broad" "nci" "public"])
+                           :methodName (rand-nth ["foo" "bar" "baz"])
+                           :methodVersion (rand-int 50)}
         ;; Real data doesn't have the following fields, but for mock data we carry the same
         ;; objects around, so initialize them here for convenience
         :inputs {"Input 1" "[some value]"
@@ -234,7 +234,8 @@
    (map
      (fn [i]
        {:workspaceName workspace-id
-        :methodConfigurationNamespace "my_test_configs"
+        :methodConfigurationNamespace (rand-nth ["Broad" "nci" "public"])
+        :methodConfigurationName (str "test_config" (inc i))
         :submissionDate (utils/rand-recent-time)
         :submissionId "46bfd579-b1d7-4f92-aab0-e44dd092b52a"
         :notstarted []
@@ -245,7 +246,6 @@
                                       :entityName "sample_01"}
                      :status "Succeeded"
                      :workflowId "97adf170-ee40-40a5-9539-76b72802e124"}]
-        :methodConfigurationName (str "test_config" (inc i))
         :status (rand-nth ["Submitted" "Done"])
         :submissionEntity {:entityType "sample"
                            :entityName (str "sample_" (inc i))}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/copy_data_workspaces.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/copy_data_workspaces.cljs
@@ -21,6 +21,7 @@
           :columns (concat
                      [{:header "Namespace" :starting-width 150}
                       {:header "Name" :starting-width 150
+                       :as-text #(get-in % ["workspace" "name"]) :sort-by :text
                        :content-renderer
                        (fn [ws]
                          (style/create-link

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
@@ -12,16 +12,6 @@
     ))
 
 
-(defn- render-map [m keys labels]
-  [:div {}
-   (map-indexed
-     (fn [i k]
-       [:div {}
-        [:span {:style {:fontWeight 200}} (str (labels i) ": ")]
-        [:span {:style {:fontweight 500}} (get m k)]])
-     keys)])
-
-
 (react/defc MethodConfigurationsList
   {:render
    (fn [{:keys [props state]}]
@@ -55,19 +45,23 @@
            [table/Table
             {:empty-message "There are no method configurations to display."
              :columns
-             [{:header "Name" :starting-width 240 :sort-by #(% "name") :filter-by #(% "name")
+             [{:header "Name" :starting-width 240 :as-text #(% "name") :sort-by :text
                :content-renderer
                (fn [config]
                  (style/create-link
                    #((:on-config-selected props) config)
                    (config "name")))}
               {:header "Root Entity Type" :starting-width 140}
-              {:header "Method" :starting-width 300 :sort-by :none
-               :filter-by #(str (% "methodNamespace") (% "methodName") (% "methodVersion"))
-               :content-renderer
-               #(render-map %
-                 ["methodNamespace" "methodName" "methodVersion"]
-                 ["Namespace" "Name" "Version"])}]
+              (let [to-list (fn [method] (mapv #(method %) ["methodNamespace" "methodName" "methodVersion"]))]
+                {:header "Method" :starting-width 800 :sort-by to-list
+                 :filter-by #(clojure.string/join " " (to-list %))
+                 :as-text #(clojure.string/join "/" (to-list %))
+                 :content-renderer
+                 (fn [method]
+                   [:div {}
+                    [:span {:style {:fontWeight 500}} (method "methodNamespace") "/" (method "methodName")]
+                    [:span {:style {:fontWeight 200 :marginLeft "2em"}} "Snapshot ID: "]
+                    [:span {:style {:fontWeight 500}} (method "methodVersion")]])})]
              :data (map
                      (fn [config]
                        [config

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs_tab.cljs
@@ -52,21 +52,18 @@
                    #((:on-config-selected props) config)
                    (config "name")))}
               {:header "Root Entity Type" :starting-width 140}
-              (let [to-list (fn [method] (mapv #(method %) ["methodNamespace" "methodName" "methodVersion"]))]
-                {:header "Method" :starting-width 800 :sort-by to-list
-                 :filter-by #(clojure.string/join " " (to-list %))
-                 :as-text #(clojure.string/join "/" (to-list %))
-                 :content-renderer
-                 (fn [method]
-                   [:div {}
-                    [:span {:style {:fontWeight 500}} (method "methodNamespace") "/" (method "methodName")]
-                    [:span {:style {:fontWeight 200 :marginLeft "2em"}} "Snapshot ID: "]
-                    [:span {:style {:fontWeight 500}} (method "methodVersion")]])})]
+              {:header "Method" :starting-width 800
+               :content-renderer
+               (fn [[namespace name snapshot-id]]
+                 [:div {}
+                  [:span {:style {:fontWeight 500}} namespace "/" name]
+                  [:span {:style {:fontWeight 200 :marginLeft "2em"}} "Snapshot ID: "]
+                  [:span {:style {:fontWeight 500}} snapshot-id]])}]
              :data (map
                      (fn [config]
                        [config
                         (config "rootEntityType")
-                        (config "methodRepoMethod")])
+                        (mapv #(get-in config ["methodRepoMethod" %]) ["methodNamespace" "methodName" "methodVersion"])])
                      configs)}]]))])
    :component-did-mount
    (fn [{:keys [this]}]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
@@ -69,8 +69,7 @@
                        (style/create-link
                         #(swap! state assoc :selected-workflow {:id (x "workflowId") :name n})
                         n)))}
-                  {:header "Last Changed" :starting-width 280
-                   :content-renderer moncommon/render-date :filter-by moncommon/render-date}
+                  {:header "Last Changed" :starting-width 280 :as-text moncommon/render-date}
                   {:header "Status" :starting-width 120
                    :content-renderer (fn [status]
                                        [:div {}
@@ -91,7 +90,7 @@
                       (row "workflowId")])
                    (filter-workflows (:active-filter @state) (:workflows props)))}]])
    :render-workflow-details
-   (fn [{:keys [props state]}]
+   (fn [{:keys [state]}]
      [:div {}
       [:div {}
        (style/create-link

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
@@ -90,7 +90,7 @@
                       (row "workflowId")])
                    (filter-workflows (:active-filter @state) (:workflows props)))}]])
    :render-workflow-details
-   (fn [{:keys [state]}]
+   (fn [{:keys [state props]}]
      [:div {}
       [:div {}
        (style/create-link

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
@@ -26,12 +26,14 @@
                             #(on-submission-clicked (submission "submissionId"))
                             (render-date submission)))}
      {:header "Status"}
-     {:header "Method Configuration" :starting-width 220}
+     {:header "Method Configuration" :starting-width 220
+      :content-renderer (fn [[namespace name]]
+                          [:div {} namespace "/" name])}
      {:header "Data Entity" :starting-width 220}]
     :data (map (fn [x]
                  [x
                   (x "status")
-                  (str (x "methodConfigurationNamespace") ":" (x "methodConfigurationName"))
+                  [(x "methodConfigurationNamespace") (x "methodConfigurationName")]
                   (str (get-in x ["submissionEntity" "entityName"])
                        " (" (get-in x ["submissionEntity" "entityType"]) ")")])
                submissions)}])

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
@@ -18,8 +18,8 @@
   [table/Table
    {:empty-message "There are no analyses to display."
     :columns
-    [{:header "Date" :starting-width 200
-      :sort-by #(% "submissionDate") :filter-by #(render-date %)
+    [{:header "Date" :starting-width 200 :as-text render-date
+      :sort-by #(% "submissionDate")
       :sort-initial :desc
       :content-renderer (fn [submission]
                           (style/create-link


### PR DESCRIPTION
:as-text creates a text representation of the table data, and acts as a fallback to several other properties.  Started using it, and made a change to the Method Configurations tab, but didn't do a full overhaul.