### PR TITLE
Download Data link in UI

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data_tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data_tab.cljs
@@ -65,7 +65,15 @@
           :onChange #(let [value (common/get-text refs "filter")
                            entities (get-in props [:entity-map value])]
                       (swap! state assoc :entities entities :entity-type value))}
-         (keys (:entity-map props)))]
+         (keys (:entity-map props)))
+       (when-let [selected-entity-type (cond
+                                    (:entity-type @state) (:entity-type @state)
+                                    (:entity-map props) (first (keys (:entity-map props))))]
+         [:a {:style {:textDecoration "none" :marginLeft "1ex"}
+              :href (str "/service/api/workspaces/" (:namespace (:workspace-id props)) "/"
+                      (:name (:workspace-id props)) "/" selected-entity-type "/export")
+              :target "_blank"}
+          "Download '" selected-entity-type "' data"])]
       (let [attribute-keys (apply union (map (fn [e] (set (keys (e "attributes")))) (:entities @state)))]
         [table/Table
          {:key (:entity-type @state)


### PR DESCRIPTION
Add a download data link in the data tab. Addresses DSDEEPB-1148.

Note: This cannot be fully tested as there is a blocking issue with respect to authorization. See DSDEEPB-1517 for more information on a separate piece of functionality (authorization cookie setting) that needs to be implemented before these download links will work.

This goes hand in hand with an Orchestration PR: https://github.com/broadinstitute/firecloud-orchestration/pull/109