### PR TITLE
Multi-copy of entities between workspaces

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -455,18 +455,21 @@
      (filter-data (:data props) (:columns props)
                   (react/call :get-filter-text (@refs "filterer"))))
    :get-body-rows
-   (fn [{:keys [state refs]} filtered-data & [initial-render?]]
-     (let [[n c] (if initial-render?
-                   [1 initial-rows-per-page]
-                   (react/call :get-current-slice (@refs "paginator")))
-           sorted-data (if-let [keyfn (:key-fn @state)] (sort-by keyfn filtered-data) filtered-data)
-           ordered-data (if (= :desc (:sort-order @state)) (reverse sorted-data) sorted-data)]
-       (take c (drop (* (dec n) c) ordered-data))))
+   (fn [{:keys [state props refs]} filtered-data & [initial-render?]]
+     (if (zero? (count (:data props)))
+       []
+       (let [[n c] (if initial-render?
+                     [1 initial-rows-per-page]
+                     (react/call :get-current-slice (@refs "paginator")))
+             sorted-data (if-let [keyfn (:key-fn @state)] (sort-by keyfn filtered-data) filtered-data)
+             ordered-data (if (= :desc (:sort-order @state)) (reverse sorted-data) sorted-data)]
+         (take c (drop (* (dec n) c) ordered-data)))))
    :set-body-rows
-   (fn [{:keys [this refs]}]
-     (let [rows (react/call :get-filtered-data this)]
-       (react/call :set-rows (@refs "body") (react/call :get-body-rows this rows))
-       (react/call :set-num-rows-visible (@refs "paginator") (count rows))))
+   (fn [{:keys [this props refs]}]
+     (when (pos? (count (:data props)))
+       (let [rows (react/call :get-filtered-data this)]
+         (react/call :set-rows (@refs "body") (react/call :get-body-rows this rows))
+         (react/call :set-num-rows-visible (@refs "paginator") (count rows)))))
    :component-did-mount
    (fn [{:keys [this state]}]
      (set! (.-onMouseMoveHandler this)

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
@@ -11,49 +11,12 @@
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
     ))
 
-(defn- labeled-field [label item]
-  [:div {}
-   [:div {:style {:width "100px" :display "inline-block"}} label]
-   item])
-
-(defn- confirmation-page [state props this from-entity from-ws]
-  [:div {}
-   [:div {:style {:position "absolute" :right 2 :top 2}}
-    [comps/Button {:icon :x :onClick #(swap! state dissoc :selected-from-entity)}]]
-   [:div {:style {:padding "20px 48px 18px"}}
-    [:h3 {} "Copy Entity:"
-     [:span {:style {:marginLeft "1.5em"}}
-      (style/create-link
-        #(swap! state dissoc :selected-from-entity :copy-error)
-        (icons/font-icon {:style {:fontSize "70%" :marginRight "0.5em"}} :angle-left)
-        "Select another entity")]]
-    (labeled-field "Entity Type: " (from-entity "entityType"))
-    (labeled-field "Entity Name: " (from-entity "name"))
-    [:div {:style {:paddingTop "1em"}}
-     [:div {:style {:float "left"}}
-      [:div {:style {:fontWeight "bold"}} "From:"]
-      (labeled-field "Namespace: " (get-in from-ws ["workspace" "namespace"]))
-      (labeled-field "Name: " (get-in from-ws ["workspace" "name"]))]
-     [:div {:style {:float "left" :padding "0 2em"}}
-      "\u27A1"]
-     [:div {:style {:float "left"}}
-      [:div {:style {:fontWeight "bold"}} "To:"]
-      (labeled-field "Namespace: " (:namespace (:workspace-id props)))
-      (labeled-field "Name: " (:name (:workspace-id props)))]
-     (common/clear-both)]
-    [:div {:style {:paddingTop "1em" :display "inline-block"}}
-     [comps/Button {:text "Copy" :onClick #(react/call :perform-copy this)}]]
-    (when (:copy-error @state)
-      [:span {:style {:color (:exception-red style/colors)}}
-       (icons/font-icon {:style {:margin "0 0.5em"}} :status-warning)
-       "Error: " (:copy-error @state)])]])
-
-(defn- entity-listing [state props refs from-ws]
+(defn- entity-listing [state props this from-ws]
   [:div {}
    [:h3 {}
-    "Select an entity to copy from "
+    "Select entities to copy from "
     (get-in from-ws ["workspace" "namespace"])
-    ":"
+    "/"
     (get-in from-ws ["workspace" "name"])
     [:span {:style {:marginLeft "1.5em"}}
      (style/create-link
@@ -61,82 +24,89 @@
        (icons/font-icon {:style {:fontSize "70%" :marginRight "0.5em"}} :angle-left)
        "Choose a different workspace")]]
    [:div {:style {:padding "0 0 0.5em 1em"}}
-    (style/create-form-label "Select Entity Type")
-    (style/create-select
-      {:style {:width "50%" :minWidth 50 :maxWidth 200} :ref "filter"
-       :onChange #(let [value (common/get-text refs "filter")
-                        entities (get-in props [:entity-map value])]
-                   (swap! state assoc :entities entities :entity-type value))}
-      (keys (:entity-map props)))]
-   (let [attribute-keys (apply union (map (fn [e] (set (keys (e "attributes")))) (:entities @state)))]
+    [:div {:style {:textAlign "center"}}
+     [comps/FilterBar {:data (:entity-list props)
+                       :buttons (mapv (fn [key] {:text key
+                                                 :filter #(= key (% "entityType"))})
+                                  (:entity-types props))
+                       :did-filter (fn [data info]
+                                     (swap! state assoc :entities data :entity-type (:text info)))}]]]
+   (let [attribute-keys (apply union (map #(set (keys (% "attributes"))) (:entities @state)))]
      [table/Table
-      {:key (:entity-type @state)
-       :empty-message "There are no entities to display."
+      {:empty-message "There are no entities to display."
+       :toolbar (fn [built-in]
+                  [:div {}
+                   [:div {:style {:float "left"}} built-in]
+                   (when (pos? (count (:selected-entities @state)))
+                     [:div {:style {:float "right"}}
+                      [comps/Button {:text "Copy" :onClick #(react/call :perform-copy this)}]])
+                   (common/clear-both)])
        :columns (concat
-                  [{:header "Entity Type" :starting-width 100}
+                  [{:starting-width 40 :resizable? false :sort-by :none :filter-by :none
+                    :content-renderer
+                    (fn [entity]
+                      (when (contains? (:selected-entities @state) entity)
+                        (icons/font-icon {:style {:color (:success-green style/colors)}} :status-done)))}
+                   {:header "Entity Type" :starting-width 100}
                    {:header "Entity Name" :starting-width 100
                     :content-renderer
                     (fn [entity]
                       (style/create-link
-                        #(do
-                          (common/scroll-to-top)
-                          (swap! state assoc :selected-from-entity entity))
+                        #(swap! state update-in [:selected-entities]
+                          (if (contains? (:selected-entities @state) entity) disj conj) entity)
                         (entity "name")))}]
                   (map (fn [k] {:header k :starting-width 100}) attribute-keys))
        :data (map (fn [m]
                     (concat
-                      [(m "entityType")
+                      [m
+                       (m "entityType")
                        m]
                       (map (fn [k] (get-in m ["attributes" k])) attribute-keys)))
                (:entities @state))}])])
 
 (react/defc EntitiesList
   {:get-initial-state
-   (fn [{:keys [props]}]
-     {:entities (get (:entity-map props) (first (keys (:entity-map props))))})
+   (fn []
+     {:selected-entities #{}})
    :render
-   (fn [{:keys [props state refs this]}]
-     (let [from-entity (:selected-from-entity @state)
-           from-ws (:selected-from-workspace props)]
+   (fn [{:keys [props state this]}]
+     (let [from-ws (:selected-from-workspace props)]
        [:div {:style {:margin "1em"}}
         (when (:copying? @state)
           [comps/Blocker {:banner "Copying..."}])
-        (if from-entity
-          (confirmation-page state props this from-entity from-ws)
-          (entity-listing state props refs from-ws))]))
+        (entity-listing state props this from-ws)]))
    :perform-copy
    (fn [{:keys [props state]}]
-     (swap! state assoc :copying? true)
-     (let [from-entity (:selected-from-entity @state)
-           entity-type (from-entity "entityType")]
-       (endpoints/call-ajax-orch
-         {:endpoint (endpoints/copy-entity-to-workspace (:workspace-id props))
-          :payload {:sourceWorkspace {:namespace (get-in props [:selected-from-workspace "workspace" "namespace"])
-                                      :name (get-in props [:selected-from-workspace "workspace" "name"])}
-                    :entityType entity-type
-                    :entityNames [(from-entity "name")]}
-          :headers {"Content-Type" "application/json"}
-          :on-done (fn [{:keys [success? status-text]}]
-                     (swap! state dissoc :copying?)
-                     (if success?
-                       (do
-                         ((:reload-data-tab props) entity-type)
-                         (swap! state dissoc :selected-from-entity))
-                       (swap! state assoc :copy-error status-text)))})))})
+     (let [grouped-entities (group-by #(% "entityType") (:selected-entities @state))]
+       (swap! state assoc :copying? true :remaining (count grouped-entities))
+       (doseq
+         [[type list] grouped-entities]
+         (endpoints/call-ajax-orch
+           {:endpoint (endpoints/copy-entity-to-workspace (:workspace-id props))
+            :payload {:sourceWorkspace {:namespace (get-in props [:selected-from-workspace "workspace" "namespace"])
+                                        :name (get-in props [:selected-from-workspace "workspace" "name"])}
+                      :entityType type
+                      :entityNames (map #(% "name") list)}
+            :headers {"Content-Type" "application/json"}
+            :on-done (fn [{:keys [success? status-text]}]
+                       (swap! state update-in [:remaining] dec)
+                       (when (zero? (:remaining @state))
+                         (swap! state assoc :copying? false :selected-entities #{})
+                         ((:reload-data-tab props) type))
+                       (when-not success?
+                         (swap! state assoc :copy-error status-text)))}))))})
 
 
 (react/defc Page
-  {:did-load-data? ; TODO: Fix this hack. It is necessary for the previous caller to know how to get back to it's original state. Ugh.
-   (fn [{:keys [state]}]
-     (:entity-map @state))
-   :render
+  {:render
    (fn [{:keys [state props]}]
      (cond
-       (:entity-map @state) [EntitiesList {:workspace-id (:workspace-id props)
-                                           :selected-from-workspace (:selected-from-workspace props)
-                                           :entity-map (:entity-map @state)
-                                           :reload-data-tab (:reload-data-tab props)
-                                           :back (:back props)}]
+       (:entity-list @state) [EntitiesList {:workspace-id (:workspace-id props)
+                                            :selected-from-workspace (:selected-from-workspace props)
+                                            :entity-list (:entity-list @state)
+                                            :entity-types (:entity-types @state)
+                                            :reload-data-tab (:reload-data-tab props)
+                                            :back (:back props)}]
        (:error-message @state) (style/create-server-error-message (:error-message @state))
        :else [:div {:style {:textAlign "center"}} [comps/Spinner {:text "Loading entities..."}]]))
    :component-did-mount
@@ -150,5 +120,8 @@
          {:endpoint (endpoints/get-entities-by-type {:name name :namespace namespace})
           :on-done (fn [{:keys [success? get-parsed-response status-text]}]
                      (if success?
-                       (swap! state assoc :entity-map (group-by #(% "entityType") (get-parsed-response)))
+                       (let [entities (get-parsed-response)]
+                         (swap! state assoc
+                           :entity-list entities
+                           :entity-types (distinct (map #(% "entityType") entities))))
                        (swap! state assoc :error status-text)))})))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
@@ -1,4 +1,4 @@
-(ns org.broadinstitute.firecloud-ui.page.workspace.copy-data-entities
+(ns org.broadinstitute.firecloud-ui.page.workspace.data.copy-data-entities
   (:require
     [clojure.set :refer [union]]
     [clojure.string]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_workspaces.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_workspaces.cljs
@@ -1,4 +1,4 @@
-(ns org.broadinstitute.firecloud-ui.page.workspace.copy-data-workspaces
+(ns org.broadinstitute.firecloud-ui.page.workspace.data.copy-data-workspaces
   (:require
     [clojure.string]
     [dmohs.react :as react]
@@ -7,7 +7,7 @@
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
     [org.broadinstitute.firecloud-ui.common.style :as style]
-    [org.broadinstitute.firecloud-ui.page.workspace.copy-data-entities :as copy-data-entities]
+    [org.broadinstitute.firecloud-ui.page.workspace.data.copy-data-entities :as copy-data-entities]
     ))
 
 (react/defc WorkspaceList

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/import_data.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/import_data.cljs
@@ -1,4 +1,4 @@
-(ns org.broadinstitute.firecloud-ui.page.workspace.import-data
+(ns org.broadinstitute.firecloud-ui.page.workspace.data.import-data
   (:require
     [clojure.string]
     [dmohs.react :as react]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
@@ -1,4 +1,4 @@
-(ns org.broadinstitute.firecloud-ui.page.workspace.data-tab
+(ns org.broadinstitute.firecloud-ui.page.workspace.data.tab
   (:require
     [dmohs.react :as react]
     [clojure.set :refer [union]]
@@ -8,8 +8,8 @@
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
-    [org.broadinstitute.firecloud-ui.page.workspace.copy-data-workspaces :as copy-data-workspaces]
-    [org.broadinstitute.firecloud-ui.page.workspace.import-data :as import-data]
+    [org.broadinstitute.firecloud-ui.page.workspace.data.copy-data-workspaces :as copy-data-workspaces]
+    [org.broadinstitute.firecloud-ui.page.workspace.data.import-data :as import-data]
     ))
 
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
@@ -49,12 +49,7 @@
 
 
 (react/defc EntitiesList
-  {:get-initial-state
-   (fn [{:keys [props]}]
-     (let [entity-type (first (:entity-types props))]
-       {:entities (filter #(= entity-type (% "entityType")) (:entity-list props))
-        :entity-type entity-type}))
-   :render
+  {:render
    (fn [{:keys [props state]}]
      [:div {}
       [:div {:style {:padding "0 0 0.5em 1em"}}
@@ -62,10 +57,12 @@
         [comps/FilterBar {:data (:entity-list props)
                           :buttons (mapv (fn [key] {:text key
                                                     :filter #(= key (% "entityType"))})
-                                     (:entity-types props))
+                                     (if-let [type (:initial-entity-type props)]
+                                       (cons type (filter #(not= % type) (:entity-types props)))
+                                       (:entity-types props)))
                           :did-filter (fn [data info]
                                         (swap! state assoc :entities data :entity-type (:text info)))}]]]
-      (let [attribute-keys (apply union (map (fn [e] (set (keys (e "attributes")))) (:entities @state)))]
+      (let [attribute-keys (apply union (map #(set (keys (% "attributes"))) (:entities @state)))]
         [table/Table
          {:key (:entity-type @state)
           :empty-message "There are no entities to display."

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -2,10 +2,10 @@
   (:require
     [dmohs.react :as react]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
-    [org.broadinstitute.firecloud-ui.page.workspace.data-tab :as data-tab]
+    [org.broadinstitute.firecloud-ui.page.workspace.data.tab :as data-tab]
     [org.broadinstitute.firecloud-ui.page.workspace.method-configs-tab :as method-configs-tab]
     [org.broadinstitute.firecloud-ui.page.workspace.monitor.tab :as monitor-tab]
-    [org.broadinstitute.firecloud-ui.page.workspace.summary.summary-tab :as summary-tab]
+    [org.broadinstitute.firecloud-ui.page.workspace.summary.tab :as summary-tab]
     ))
 
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
@@ -1,4 +1,4 @@
-(ns org.broadinstitute.firecloud-ui.page.workspace.summary.summary-tab
+(ns org.broadinstitute.firecloud-ui.page.workspace.summary.tab
   (:require
     [clojure.string :refer [trim capitalize blank?]]
     [dmohs.react :as react]


### PR DESCRIPTION
Not that much different visually, now clicking entities toggles their selection, and a copy button appears for nonempty selections.  Error reporting has been lost, but there's another story for previewing conflicts that would overwrite any work I would do on that, so I'm leaving it as-is for now.