### PR TITLE
Monitor tab improvements

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -97,11 +97,11 @@
 
 
 (defn compute-status [workspace]
-  (let [lastSuccess (js/moment (get-in workspace ["workspaceSubmissionStats" "lastSuccessDate"]))
-        lastFailure (js/moment (get-in workspace ["workspaceSubmissionStats" "lastFailureDate"]))
-        count (get-in workspace ["workspaceSubmissionStats" "runningSubmissionsCount"])]
-    (cond (pos? count) "Running"
-          (.isAfter lastFailure lastSuccess) "Exception"
+  (let [last-success (js/moment (get-in workspace ["workspaceSubmissionStats" "lastSuccessDate"]))
+        last-failure (js/moment (get-in workspace ["workspaceSubmissionStats" "lastFailureDate"]))
+        count-running (get-in workspace ["workspaceSubmissionStats" "runningSubmissionsCount"])]
+    (cond (pos? count-running) "Running"
+          (.isAfter last-failure last-success) "Exception"
           :else "Complete")))
 
 (defn gcs-uri->download-url [gcs-uri]

--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -97,10 +97,12 @@
 
 
 (defn compute-status [workspace]
-  (let [count (get-in workspace ["workspaceSubmissionStats" "runningSubmissionsCount"])]
-    (cond (not (nil? (get-in workspace ["workspaceSubmissionStats" "lastFailureDate"]))) "Exception"
-          (zero? count) "Complete"
-          :else "Running")))
+  (let [lastSuccess (js/moment (get-in workspace ["workspaceSubmissionStats" "lastSuccessDate"]))
+        lastFailure (js/moment (get-in workspace ["workspaceSubmissionStats" "lastFailureDate"]))
+        count (get-in workspace ["workspaceSubmissionStats" "runningSubmissionsCount"])]
+    (cond (pos? count) "Running"
+          (.isAfter lastFailure lastSuccess) "Exception"
+          :else "Complete")))
 
 (defn gcs-uri->download-url [gcs-uri]
   (let [matcher (re-find #"gs://([^/]+)/(.+)" gcs-uri)]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/common.cljs
@@ -7,6 +7,11 @@
     ))
 
 
+(defn- all-success? [submission]
+  (and (every? #(= "Succeeded" (% "status")) (submission "workflows"))
+    (zero? (count (submission "notstarted")))))
+
+
 (defn render-date [date]
   (let [m (js/moment date)]
     (str (.format m "L [at] LTS") " (" (.fromNow m) ")")))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
@@ -12,18 +12,14 @@
     ))
 
 
-(defn- all-success? [submission]
-  (and (every? #(= "Succeeded" (% "status")) (submission "workflows"))
-       (zero? (count (submission "notstarted")))))
-
 (defn- color-for-submission [submission]
   (cond (= "Submitted" (submission "status")) (:running-blue style/colors)
-        (all-success? submission) (:success-green style/colors)
+        (moncommon/all-success? submission) (:success-green style/colors)
         :else (:exception-red style/colors)))
 
 (defn- icon-for-submission [submission]
   (cond (= "Submitted" (submission "status")) [comps/RunningIcon {:size 36}]
-        (all-success? submission) [comps/CompleteIcon {:size 36}]
+        (moncommon/all-success? submission) [comps/CompleteIcon {:size 36}]
         :else [comps/ExceptionIcon {:size 36}]))
 
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
@@ -3,9 +3,11 @@
     [dmohs.react :as react]
     cljsjs.moment
     [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.common.icons :as icons]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
+    [org.broadinstitute.firecloud-ui.page.workspace.monitor.common :as moncommon]
     [org.broadinstitute.firecloud-ui.page.workspace.monitor.submission-details
      :as submission-details]
     ))
@@ -25,17 +27,26 @@
                           (style/create-link
                             #(on-submission-clicked (submission "submissionId"))
                             (render-date submission)))}
-     {:header "Status"}
-     {:header "Method Configuration" :starting-width 220
+     {:header "Status" :as-text #(% "status") :sort-by :text
+      :content-renderer (fn [submission]
+                          [:div {}
+                           (when (and (= "Done" (submission "status"))
+                                      (not (moncommon/all-success? submission)))
+                             (icons/font-icon {:style {:color (:exception-red style/colors)
+                                                       :marginRight 8}} :status-warning))
+                           (submission "status")])}
+     {:header "Method Configuration" :starting-width 300
       :content-renderer (fn [[namespace name]]
                           [:div {} namespace "/" name])}
-     {:header "Data Entity" :starting-width 220}]
+     {:header "Data Entity" :starting-width 220}
+     {:header "Submitted By" :starting-width 220}]
     :data (map (fn [x]
                  [x
-                  (x "status")
+                  x
                   [(x "methodConfigurationNamespace") (x "methodConfigurationName")]
                   (str (get-in x ["submissionEntity" "entityName"])
-                       " (" (get-in x ["submissionEntity" "entityType"]) ")")])
+                       " (" (get-in x ["submissionEntity" "entityType"]) ")")
+                  (x "submitter")])
                submissions)}])
 
 


### PR DESCRIPTION
From the JIRA item:
* *Default sort by submission date descending* -- was already done
* *Show running vs. done status and error status in submissions list* -- This column already existed, so I added a red "!" icon in case it's the "done but with errors" status.  Other than that, I can't think of a good way to include more status/error info in the table without over-cluttering things.  That's what the detail page is for.
* *Details: status icon takes up too much space* -- I think it's fine.  It's the same component as the workspace summary tab.

Also, I changed the algorithm for determining the workspace's overall state.  Previously, it was reporting as "error" if any past submission had failed.  Now it checks the most recent success and failure times and only reports failure if the most recent submission failed.