### PR TITLE
Workspace details additions

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -97,11 +97,13 @@
 
 
 (defn compute-status [workspace]
-  (let [last-success (js/moment (get-in workspace ["workspaceSubmissionStats" "lastSuccessDate"]))
-        last-failure (js/moment (get-in workspace ["workspaceSubmissionStats" "lastFailureDate"]))
+  (let [last-success (get-in workspace ["workspaceSubmissionStats" "lastSuccessDate"])
+        last-failure (get-in workspace ["workspaceSubmissionStats" "lastFailureDate"])
         count-running (get-in workspace ["workspaceSubmissionStats" "runningSubmissionsCount"])]
     (cond (pos? count-running) "Running"
-          (.isAfter last-failure last-success) "Exception"
+          (and last-failure
+               (or (not last-success)
+                   (.isAfter (js/moment last-failure) (js/moment last-success)))) "Exception"
           :else "Complete")))
 
 (defn gcs-uri->download-url [gcs-uri]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/common.cljs
@@ -7,7 +7,7 @@
     ))
 
 
-(defn- all-success? [submission]
+(defn all-success? [submission]
   (and (every? #(= "Succeeded" (% "status")) (submission "workflows"))
     (zero? (count (submission "notstarted")))))
 


### PR DESCRIPTION
* Created by/date
* empty descrition placeholder
* pluralized workspace owner
* display count of running submissions when running, in the status box
* display count of total submissions and failures at bottom

Also re-re-fixed issues with workspace status calculation.  The last-success vs. last-failure check was failing if one/both of those fields were missing.  Maybe Rawls should be doing this?