### PR TITLE
Fix infinite recursion by turning off advanced optimizations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,10 @@
                                                             ":3449/figwheel-ws")}}}}}
              :minimized {:cljsbuild
                          {:builds {:client {:compiler
-                                            {:optimizations :advanced
+                                            {;; As of 10/29/15, advanced optimization triggers
+                                             ;; infinite recursion, which I was not able to figure
+                                             ;; out.
+                                             :optimizations :simple
                                              :pretty-print false
                                              :closure-defines {"goog.DEBUG" false}}}}}}}
   :cljsbuild {:builds {:client {:source-paths ["src/cljs"]


### PR DESCRIPTION
I tried figuring out the problem, but couldn't diagnose it. The error was triggered from React, but I can't be certain that is where the problem originated. It's easily triggered by clicking the "Create New Workspace..." button after compiling with advanced optimizations. Turning them off fixes the problem, which is a bad UI bug, so it's worth doing and figuring out the underlying issue later.