### PR TITLE
Implemented error viewer, used for the file import

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -6,7 +6,7 @@
    :pgup 33 :pgdown 34 :end 35 :home 67 :left 37 :up 38 :right 39 :down 40 :insert 45 :del 46})
 
 (defn create-key-handler
-  ([keys func] (create-key-handler keys (fn [e] true) func))
+  ([keys func] (create-key-handler keys (constantly true) func))
   ([keys modifier func] (fn [e]
                           (when (modifier e)
                             (let [keycode (.-keyCode e)]
@@ -68,13 +68,6 @@
        (- elem-center-x (/ (.-innerWidth js/window) 2))
        (- elem-center-y (/ (.-innerHeight js/window) 2))
        duration))))
-
-(defn is-in-view [elem]
-  (let [doc-view-top (.-scrollY js/window)
-        doc-view-bottom (+ doc-view-top (.-innerHeight js/window))
-        elem-top (.-offsetTop elem)
-        elem-bottom (+ elem-top (.-offsetHeight elem))]
-    (and (< doc-view-top elem-top) (> doc-view-bottom elem-bottom))))
 
 
 (def ^:private user-select-keys ["userSelect" "webkitTouchCallout" "webkitUserSelect"

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -5,8 +5,6 @@
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.icons :as icons]
     [org.broadinstitute.firecloud-ui.common.style :as style]
-    [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
-    [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
 
 
@@ -62,9 +60,9 @@
                                 :backgroundColor (when (:active? props) "white")
                                 :cursor "pointer"
                                 :position "relative"}
-                        :onMouseOver (fn [e] (swap! state assoc :hovering? true))
-                        :onMouseOut (fn [e] (swap! state assoc :hovering? false))
-                        :onClick (fn [e] ((:onClick props) e))}
+                        :onMouseOver #(swap! state assoc :hovering? true)
+                        :onMouseOut #(swap! state assoc :hovering? false)
+                        :onClick #((:onClick props) %)}
                   (:text props)
                   (when (or (:active? props) (:hovering? @state))
                     [:div {:style {:position "absolute" :top "-0.5ex" :left 0
@@ -101,89 +99,11 @@
           [:div {} (apply render (.-renderArgs this))])])}))
 
 
-(react/defc Dialog
-  {:get-default-props
-   (fn []
-     {:blocking? true
-      :cycle-focus? false})
-   :render
-   (fn [{:keys [props state]}]
-     (let [content (:content props)
-           anchored? (not (nil? (:get-anchor-dom-node props)))]
-       (assert (react/valid-element? content)
-               (subs (str "Not a react element: " content) 0 200))
-       (when (or (not anchored?) (:position @state))
-         [:div {:style {:backgroundColor (if (:blocking? props)
-                                           "rgba(110, 110, 110, 0.4)"
-                                           "rgba(210, 210, 210, 0.4)")
-                        :position "absolute" :zIndex 8888
-                        :top 0 :left 0 :right 0 :height (.. js/document -body -offsetHeight)}
-                :onKeyDown (common/create-key-handler [:esc] #((:dismiss-self props)))
-                :onClick (when-not (:blocking? props) #((:dismiss-self props)))}
-          [:div {:style (if anchored?
-                          {:position "absolute" :backgroundColor "#fff"
-                           :top (get-in @state [:position :top])
-                           :left (get-in @state [:position :left])}
-                          {:transform "translate(-50%, 0px)" :backgroundColor "#fff"
-                           :position "relative" :marginBottom 60
-                           :top 60 :left "50%" :width (:width props)})
-                 :onClick (when-not (:blocking? props) #(.stopPropagation %))}
-           content]])))
-   :component-did-mount
-   (fn [{:keys [this props state]}]
-     (when-let [get-dom-node (:get-anchor-dom-node props)]
-       (swap! state assoc :position {:top (.. (get-dom-node) -offsetTop)
-                                     :left (.. (get-dom-node) -offsetLeft)}))
-     (when-let [get-first (:get-first-element-dom-node props)]
-       (common/focus-and-select (get-first))
-       (when-let [get-last (:get-last-element-dom-node props)]
-         (.addEventListener (get-first) "keydown" (common/create-key-handler [:tab] #(.-shiftKey %)
-                                                    (fn [e] (.preventDefault e)
-                                                      (when (:cycle-focus? props)
-                                                        (.focus (get-last))))))
-         (.addEventListener (get-last) "keydown" (common/create-key-handler [:tab] #(not (.-shiftKey %))
-                                                   (fn [e] (.preventDefault e)
-                                                     (when (:cycle-focus? props)
-                                                       (.focus (get-first))))))))
-     (set! (.-onKeyDownHandler this)
-           (common/create-key-handler [:esc] #((:dismiss-self props))))
-     (.addEventListener js/window "keydown" (.-onKeyDownHandler this)))
-   :component-will-unmount
-   (fn [{:keys [this]}]
-     (.removeEventListener js/window "keydown" (.-onKeyDownHandler this)))})
-
-
 (react/defc XButton
   {:render
    (fn [{:keys [props]}]
      [:div {:style {:position "absolute" :top 4 :right 4}}
       [Button {:icon :x :onClick #((:dismiss props))}]])})
-
-
-(react/defc OKCancelForm
-  {:get-default-props
-   (fn []
-     {:show-cancel? true})
-   :render
-   (fn [{:keys [props]}]
-     [:div {}
-      [:div {:style {:borderBottom (str "1px solid " (:line-gray style/colors))
-                     :padding "20px 48px 18px"
-                     :fontSize "137%" :fontWeight 400 :lineHeight 1}}
-       (:header props)]
-      [:div {:style {:padding "22px 48px 40px" :backgroundColor (:background-gray style/colors)}}
-       (:content props)
-       [:div {:style {:marginTop 40 :textAlign "center"}}
-        (when (:show-cancel? props)
-          [:a {:style {:marginRight 27 :marginTop 2 :padding "0.5em"
-                       :display "inline-block"
-                       :fontSize "106%" :fontWeight 500 :textDecoration "none"
-                       :color (:button-blue style/colors)}
-               :href "javascript:;"
-               :onClick #((:dismiss-self props))
-               :onKeyDown (common/create-key-handler [:space :enter] #((:dismiss-self props)))}
-           "Cancel"])
-        (:ok-button props)]]])})
 
 
 (react/defc Blocker
@@ -197,56 +117,6 @@
                        :backgroundColor "#fff" :padding "2em"}}
          [Spinner {:text (:banner props)}]]]))})
 
-
-(react/defc CompleteIcon
-  {:get-default-props
-   (fn []
-     {:color (:success-green style/colors)
-      :size 24})
-   :render
-   (fn [{:keys [props]}]
-     [:span {:style {:display "inline-block" :position "relative" :verticalAlign "middle"
-                     :width (int (* 1.27 (:size props)))
-                     :height (int (* 1.27 (:size props)))
-                     :backgroundColor "fff" :borderRadius "100%"}}
-      (style/center {}
-        (icons/font-icon {:style {:color (:color props) :fontSize (int (* 0.5 (:size props)))}}
-          :status-done))])})
-
-(react/defc RunningIcon
-  {:get-default-props
-   (fn []
-     {:color (:success-green style/colors)
-      :size 24})
-   :render
-   (fn [{:keys [props]}]
-     (let [hamburger-height (int (/ (:size props) 6))
-           spacer-height (int (/ (- (:size props) 4 (* 3 hamburger-height)) 2))
-           hamburger (fn [color] [:div {:style {:height hamburger-height
-                                                :width (:size props)
-                                                :borderRadius hamburger-height
-                                                :backgroundColor color}}])
-           spacer [:div {:style {:height spacer-height}}]]
-       [:span {:style {:display "inline-block" :position "relative" :verticalAlign "middle"
-                       :height (:size props) :width (:size props)}}
-        (style/center {}
-          [:div {}
-           (hamburger "white")
-           spacer
-           (hamburger (:color props))
-           spacer
-           (hamburger (:color props))])]))})
-
-(react/defc ExceptionIcon
-  {:get-default-props
-   (fn []
-     {:size 24})
-   :render
-   (fn [{:keys [props]}]
-     [:span {:style {:display "inline-block" :position "relative" :verticalAlign "middle"
-                     :height (:size props) :width (:size props)}}
-      (style/center {}
-        (icons/font-icon {:style {:color "#fff" :fontSize (:size props)}} :status-warning))])})
 
 (react/defc StatusLabel
   {:render
@@ -329,85 +199,57 @@
         [:div {:style {:fontStyle "italic" :fontSize "90%"}} "No documentation provided"]
         [:div {:style {:fontSize "90%"}} (entity "documentation")])])})
 
-(react/defc GCSFilePreviewLink
-  {:render
-   (fn [{:keys [props state refs this]}]
-     (assert (:bucket-name props) "No bucket name provided")
-     (assert (:object props) "No GCS object provided")
-     [:div {}
-      [:a {:href "javascript:;"
-           :onClick #(react/call :show-dialog this)}
-       (:gcs-uri props)]
-      (when (or (:show-dialog? @state) (:loading? @state))
-        (let [{:keys [data error]} (:response @state)
-              data-size (when data (data "size"))
-              labeled (fn [label & contents]
-                        [:div {}
-                         [:div {:style {:display "inline-block" :width 120}} (str label ": ")]
-                         contents])]
-          [:div {:style {:position "fixed" :top 0 :left 0 :right 0 :bottom 0 :zIndex 9999
-                         :fontSize "initial" :fontWeight "initial"}}
-           [Dialog
-            {:dismiss-self #(swap! state dissoc :show-dialog?)
-             :width "75%"
-             :content
-             (react/create-element
-               [OKCancelForm
-                {:header "File Details"
-                 :content (react/create-element
-                            [:div {}
-                             (labeled "Google Bucket" (:bucket-name props))
-                             (labeled "Object" (:object props))
-                             (when (:loading? @state)
-                               [Spinner {:text "Getting file info..."}])
-                             (when data
-                               [:div {:style {:marginTop "1em"}}
-                                (labeled "File size"
-                                  (common/format-filesize data-size)
-                                  [:span {:style {:marginLeft "1em"}}
-                                   [:a {:href (data "mediaLink")} "Download"]]
-                                  (when (> data-size 100000000)
-                                    [:span {:style {:color (:exception-red style/colors) :marginLeft "2ex"}}
-                                     (icons/font-icon {:style {:fontSize "100%" :verticalAlign "middle" :marginRight "1ex"}}
-                                       :status-warning-triangle)
-                                     "Warning: Downloading this file may incur a large data egress charge"]))
-                                (if (:show-details? @state)
-                                  [:div {}
-                                   (labeled "Created" (common/format-date (data "timeCreated")))
-                                   (labeled "Updated" (common/format-date (data "updated")))
-                                   (labeled "MD5" (data "md5Hash"))
-                                   (style/create-link
-                                     #(swap! state dissoc :show-details?)
-                                     "Collapse")]
-                                  (style/create-link
-                                    #(swap! state assoc :show-details? true)
-                                    "More info"))])
-                             (when error
-                               [:div {:style {:marginTop "1em"}}
-                                [:span {:style {:color (:exception-red style/colors)}} "Error! "]
-                                "This file was not found."
-                                (if (:show-error-details? @state)
-                                  [:div {}
-                                   [:pre {} error]
-                                   (style/create-link
-                                     #(swap! state dissoc :show-error-details?)
-                                     "Hide detail")]
-                                  [:div {}
-                                   (style/create-link
-                                     #(swap! state assoc :show-error-details? true)
-                                     "Show full error response")])])])
-                 :dismiss-self #(swap! state dissoc :show-dialog?)
-                 :show-cancel? false
-                 :ok-button [Button {:text "Done" :onClick #(swap! state dissoc :show-dialog?)}]}])}]]))])
-   :show-dialog
-   (fn [{:keys [state props]}]
-     (if (:response @state)
-       (swap! state assoc :show-dialog? true)
-       (do
-         (swap! state assoc :loading? true)
-         (endpoints/call-ajax-orch
-           {:endpoint (endpoints/get-gcs-stats (:bucket-name props) (:object props))
-            :on-done (fn [{:keys [success? get-parsed-response xhr]}]
-                       (swap! state assoc :show-dialog? true :loading? false
-                         :response (if success? {:data (get-parsed-response)}
-                                                {:error (.-responseText xhr)})))}))))})
+
+(declare CauseViewer)
+(react/defc ErrorViewer
+  (let [StackTraceViewer
+        (react/create-class
+          {:render
+           (fn [{:keys [props state]}]
+             (if (:expanded? @state)
+               [:div {:style {:overflowX "auto"}}
+                [:div {} "Stack Trace:"]
+                (map
+                  (fn [line]
+                    (let [[class method file num]
+                          (map #(line %) ["className" "methodName" "fileName" "lineNumber"])]
+                      [:div {:style {:marginLeft "1em" :whiteSpace "nowrap"}}
+                       (str "at " class "." method " (" file ":" num ")")]))
+                  (:lines props))
+                (style/create-link #(swap! state assoc :expanded? false) "Hide Stack Trace")]
+               (style/create-link #(swap! state assoc :expanded? true) "Show Stack Trace")))})
+        CauseViewer
+        (react/create-class
+          {:render
+           (fn [{:keys [props state]}]
+             (if (:expanded? @state)
+               (let [[source causes stack-trace message]
+                     (map #(props %) ["source" "causes" "stackTrace" "message"])]
+                 [:div {:style {:marginLeft "1em"}}
+                  [:div {} "Message: " message]
+                  (when source [:div {} "Source: " source])
+                  (when-not (empty? causes)
+                    [:div {}
+                     [:div {} (str "Cause" (when (> (count causes) 1) "s") ":")]
+                     (map (fn [cause] [CauseViewer cause]) causes)])
+                  (when-not (empty? stack-trace)
+                    [StackTraceViewer {:lines stack-trace}])
+                  (style/create-link #(swap! state assoc :expanded? false) "Hide Cause")])
+               (style/create-link #(swap! state assoc :expanded? true) "Show Cause")))})]
+    {:render
+     (fn [{:keys [props]}]
+       (let [[source status-code causes stack-trace message]
+             (map #(get-in props [:error %]) ["source" "statusCode" "causes" "stackTrace" "message"])]
+         [:div {:style {:textAlign "initial"}}
+          [:div {}
+           [:span {:style {:paddingRight "1ex"}}
+            (icons/font-icon {:style {:color (:exception-red style/colors)}}
+              :status-warning-triangle)]
+           (str "Error " status-code ": " message)]
+          (when source [:div {} "Source: " source])
+          (when-not (empty? causes)
+            [:div {}
+             [:div {} (str "Cause" (when (> (count causes) 1) "s") ":")]
+             (map (fn [cause] [CauseViewer cause]) causes)])
+          (when-not (empty? stack-trace)
+            [StackTraceViewer {:lines stack-trace}])]))}))

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/dialog.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/dialog.cljs
@@ -1,0 +1,170 @@
+(ns org.broadinstitute.firecloud-ui.common.dialog
+  (:require
+    [dmohs.react :as react]
+    [org.broadinstitute.firecloud-ui.common :as common]
+    [org.broadinstitute.firecloud-ui.common.components :refer [Spinner Button]]
+    [org.broadinstitute.firecloud-ui.common.icons :as icons]
+    [org.broadinstitute.firecloud-ui.common.style :as style]
+    [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
+    ))
+
+(react/defc Dialog
+  {:get-default-props
+   (fn []
+     {:blocking? true
+      :cycle-focus? false})
+   :render
+   (fn [{:keys [props state]}]
+     (let [content (:content props)
+           anchored? (not (nil? (:get-anchor-dom-node props)))]
+       (assert (react/valid-element? content)
+         (subs (str "Not a react element: " content) 0 200))
+       (when (or (not anchored?) (:position @state))
+         [:div {:style {:backgroundColor (if (:blocking? props)
+                                           "rgba(110, 110, 110, 0.4)"
+                                           "rgba(210, 210, 210, 0.4)")
+                        :position "absolute" :zIndex 8888
+                        :top 0 :left 0 :right 0 :height (.. js/document -body -offsetHeight)}
+                :onKeyDown (common/create-key-handler [:esc] #((:dismiss-self props)))
+                :onClick (when-not (:blocking? props) #((:dismiss-self props)))}
+          [:div {:style (if anchored?
+                          {:position "absolute" :backgroundColor "#fff"
+                           :top (get-in @state [:position :top])
+                           :left (get-in @state [:position :left])}
+                          {:transform "translate(-50%, 0px)" :backgroundColor "#fff"
+                           :position "relative" :marginBottom 60
+                           :top 60 :left "50%" :width (:width props)})
+                 :onClick (when-not (:blocking? props) #(.stopPropagation %))}
+           content]])))
+   :component-did-mount
+   (fn [{:keys [this props state]}]
+     (when-let [get-dom-node (:get-anchor-dom-node props)]
+       (swap! state assoc :position {:top (.. (get-dom-node) -offsetTop)
+                                     :left (.. (get-dom-node) -offsetLeft)}))
+     (when-let [get-first (:get-first-element-dom-node props)]
+       (common/focus-and-select (get-first))
+       (when-let [get-last (:get-last-element-dom-node props)]
+         (.addEventListener (get-first) "keydown" (common/create-key-handler [:tab] #(.-shiftKey %)
+                                                    (fn [e] (.preventDefault e)
+                                                      (when (:cycle-focus? props)
+                                                        (.focus (get-last))))))
+         (.addEventListener (get-last) "keydown" (common/create-key-handler [:tab] #(not (.-shiftKey %))
+                                                   (fn [e] (.preventDefault e)
+                                                     (when (:cycle-focus? props)
+                                                       (.focus (get-first))))))))
+     (set! (.-onKeyDownHandler this)
+       (common/create-key-handler [:esc] #((:dismiss-self props))))
+     (.addEventListener js/window "keydown" (.-onKeyDownHandler this)))
+   :component-will-unmount
+   (fn [{:keys [this]}]
+     (.removeEventListener js/window "keydown" (.-onKeyDownHandler this)))})
+
+
+(react/defc OKCancelForm
+  {:get-default-props
+   (fn []
+     {:show-cancel? true})
+   :render
+   (fn [{:keys [props]}]
+     [:div {}
+      [:div {:style {:borderBottom (str "1px solid " (:line-gray style/colors))
+                     :padding "20px 48px 18px"
+                     :fontSize "137%" :fontWeight 400 :lineHeight 1}}
+       (:header props)]
+      [:div {:style {:padding "22px 48px 40px" :backgroundColor (:background-gray style/colors)}}
+       (:content props)
+       [:div {:style {:marginTop 40 :textAlign "center"}}
+        (when (:show-cancel? props)
+          [:a {:style {:marginRight 27 :marginTop 2 :padding "0.5em"
+                       :display "inline-block"
+                       :fontSize "106%" :fontWeight 500 :textDecoration "none"
+                       :color (:button-blue style/colors)}
+               :href "javascript:;"
+               :onClick #((:dismiss-self props))
+               :onKeyDown (common/create-key-handler [:space :enter] #((:dismiss-self props)))}
+           "Cancel"])
+        (:ok-button props)]]])})
+
+
+(react/defc GCSFilePreviewLink
+  {:render
+   (fn [{:keys [props state this]}]
+     (assert (:bucket-name props) "No bucket name provided")
+     (assert (:object props) "No GCS object provided")
+     [:div {}
+      [:a {:href "javascript:;"
+           :onClick #(react/call :show-dialog this)}
+       (:gcs-uri props)]
+      (when (or (:show-dialog? @state) (:loading? @state))
+        (let [{:keys [data error]} (:response @state)
+              data-size (when data (data "size"))
+              labeled (fn [label & contents]
+                        [:div {}
+                         [:div {:style {:display "inline-block" :width 120}} (str label ": ")]
+                         contents])]
+          [:div {:style {:position "fixed" :top 0 :left 0 :right 0 :bottom 0 :zIndex 9999
+                         :fontSize "initial" :fontWeight "initial"}}
+           [Dialog
+            {:dismiss-self #(swap! state dissoc :show-dialog?)
+             :width "75%"
+             :content
+             (react/create-element
+               [OKCancelForm
+                {:header "File Details"
+                 :content (react/create-element
+                            [:div {}
+                             (labeled "Google Bucket" (:bucket-name props))
+                             (labeled "Object" (:object props))
+                             (when (:loading? @state)
+                               [Spinner {:text "Getting file info..."}])
+                             (when data
+                               [:div {:style {:marginTop "1em"}}
+                                (labeled "File size"
+                                  (common/format-filesize data-size)
+                                  [:span {:style {:marginLeft "1em"}}
+                                   [:a {:href (data "mediaLink")} "Download"]]
+                                  (when (> data-size 100000000)
+                                    [:span {:style {:color (:exception-red style/colors) :marginLeft "2ex"}}
+                                     (icons/font-icon {:style {:fontSize "100%" :verticalAlign "middle" :marginRight "1ex"}}
+                                       :status-warning-triangle)
+                                     "Warning: Downloading this file may incur a large data egress charge"]))
+                                (if (:show-details? @state)
+                                  [:div {}
+                                   (labeled "Created" (common/format-date (data "timeCreated")))
+                                   (labeled "Updated" (common/format-date (data "updated")))
+                                   (labeled "MD5" (data "md5Hash"))
+                                   (style/create-link
+                                     #(swap! state dissoc :show-details?)
+                                     "Collapse")]
+                                  (style/create-link
+                                    #(swap! state assoc :show-details? true)
+                                    "More info"))])
+                             (when error
+                               [:div {:style {:marginTop "1em"}}
+                                [:span {:style {:color (:exception-red style/colors)}} "Error! "]
+                                "This file was not found."
+                                (if (:show-error-details? @state)
+                                  [:div {}
+                                   [:pre {} error]
+                                   (style/create-link
+                                     #(swap! state dissoc :show-error-details?)
+                                     "Hide detail")]
+                                  [:div {}
+                                   (style/create-link
+                                     #(swap! state assoc :show-error-details? true)
+                                     "Show full error response")])])])
+                 :dismiss-self #(swap! state dissoc :show-dialog?)
+                 :show-cancel? false
+                 :ok-button [Button {:text "Done" :onClick #(swap! state dissoc :show-dialog?)}]}])}]]))])
+   :show-dialog
+   (fn [{:keys [state props]}]
+     (if (:response @state)
+       (swap! state assoc :show-dialog? true)
+       (do
+         (swap! state assoc :loading? true)
+         (endpoints/call-ajax-orch
+           {:endpoint (endpoints/get-gcs-stats (:bucket-name props) (:object props))
+            :on-done (fn [{:keys [success? get-parsed-response xhr]}]
+                       (swap! state assoc :show-dialog? true :loading? false
+                         :response (if success? {:data (get-parsed-response)}
+                                                {:error (.-responseText xhr)})))}))))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/icons.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/icons.cljs
@@ -1,6 +1,9 @@
 (ns org.broadinstitute.firecloud-ui.common.icons
   (:require
-    [org.broadinstitute.firecloud-ui.utils :as utils]))
+    [dmohs.react :as react]
+    [org.broadinstitute.firecloud-ui.common.style :as style]
+    [org.broadinstitute.firecloud-ui.utils :as utils]
+    ))
 
 (def ^:private icon-keys {:activity ""
                           :angle-left ""
@@ -26,3 +29,53 @@
   [:span (utils/deep-merge {:style {:fontFamily "fontIcons"}} props) (key icon-keys)])
 
 (defn icon-text [key] (key icon-keys))
+
+(react/defc CompleteIcon
+  {:get-default-props
+   (fn []
+     {:color (:success-green style/colors)
+      :size 24})
+   :render
+   (fn [{:keys [props]}]
+     [:span {:style {:display "inline-block" :position "relative" :verticalAlign "middle"
+                     :width (int (* 1.27 (:size props)))
+                     :height (int (* 1.27 (:size props)))
+                     :backgroundColor "fff" :borderRadius "100%"}}
+      (style/center {}
+        (font-icon {:style {:color (:color props) :fontSize (int (* 0.5 (:size props)))}}
+          :status-done))])})
+
+(react/defc RunningIcon
+  {:get-default-props
+   (fn []
+     {:color (:success-green style/colors)
+      :size 24})
+   :render
+   (fn [{:keys [props]}]
+     (let [hamburger-height (int (/ (:size props) 6))
+           spacer-height (int (/ (- (:size props) 4 (* 3 hamburger-height)) 2))
+           hamburger (fn [color] [:div {:style {:height hamburger-height
+                                                :width (:size props)
+                                                :borderRadius hamburger-height
+                                                :backgroundColor color}}])
+           spacer [:div {:style {:height spacer-height}}]]
+       [:span {:style {:display "inline-block" :position "relative" :verticalAlign "middle"
+                       :height (:size props) :width (:size props)}}
+        (style/center {}
+          [:div {}
+           (hamburger "white")
+           spacer
+           (hamburger (:color props))
+           spacer
+           (hamburger (:color props))])]))})
+
+(react/defc ExceptionIcon
+  {:get-default-props
+   (fn []
+     {:size 24})
+   :render
+   (fn [{:keys [props]}]
+     [:span {:style {:display "inline-block" :position "relative" :verticalAlign "middle"
+                     :height (:size props) :width (:size props)}}
+      (style/center {}
+        (font-icon {:style {:color "#fff" :fontSize (:size props)}} :status-warning))])})

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table.cljs
@@ -3,6 +3,7 @@
    [dmohs.react :as react]
    [org.broadinstitute.firecloud-ui.common :as common]
    [org.broadinstitute.firecloud-ui.common.components :as comps]
+   [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
    [org.broadinstitute.firecloud-ui.common.style :as style]
    [org.broadinstitute.firecloud-ui.common.table-utils :as table-utils]
    [org.broadinstitute.firecloud-ui.utils :as utils]
@@ -144,7 +145,7 @@
                                    :ref "col-edit-button"
                                    :onClick #(swap! state assoc :reordering-columns? true)}]
                     (when (:reordering-columns? @state)
-                      [comps/Dialog
+                      [dialog/Dialog
                        {:get-anchor-dom-node #(.getDOMNode (@refs "col-edit-button"))
                         :blocking? false
                         :dismiss-self #(swap! state assoc :reordering-columns? false)

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/methods_configs_acl.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/methods_configs_acl.cljs
@@ -4,6 +4,7 @@
    [clojure.string :refer [trim]]
    [org.broadinstitute.firecloud-ui.common :as common]
    [org.broadinstitute.firecloud-ui.common.components :as comps]
+   [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
    [org.broadinstitute.firecloud-ui.common.style :as style]
    [org.broadinstitute.firecloud-ui.common.table :as table]
    [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
@@ -25,7 +26,7 @@
 (react/defc AgoraPermsEditor
   {:render
    (fn [{:keys [props state this]}]
-     [comps/Dialog
+     [dialog/Dialog
       {:width "75%"
        :blocking? true
        :dismiss-self (:dismiss-self props)

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/import_data.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/import_data.cljs
@@ -50,8 +50,7 @@
            (icons/font-icon {:style {:fontSize "200%" :color (:success-green style/colors)}} :status-done)
            [:span {:style {:margin "-0.5em 0 0 1em"}} "Success!"]]
           [:div {:style {:paddingTop "1em"}}
-           (icons/font-icon {:style {:fontSize "200%" :color (:exception-red style/colors)}} :status-warning)
-           [:span {:style {:margin "-0.5em 0 0 1em"}} "Error: " (:error-message result)]]))])
+           [comps/ErrorViewer {:error (:error result)}]]))])
    :do-upload
    (fn [{:keys [props state]}]
      (swap! state assoc :loading? true)
@@ -59,10 +58,10 @@
        {:endpoint (endpoints/import-entities (:workspace-id props))
         :raw-data (utils/generate-form-data {:entities (:file @state)})
         :encType "multipart/form-data"
-        :on-done (fn [{:keys [success? xhr]}]
+        :on-done (fn [{:keys [success? xhr get-parsed-response]}]
                    (swap! state dissoc :loading? :file :file-contents)
                    (if success?
                      (do
                        (swap! state assoc :upload-result {:success? true})
                        ((:reload-data-tab props) (.-responseText xhr)))
-                     (swap! state assoc :upload-result {:success? false :error-message (.-responseText xhr)})))}))})
+                     (swap! state assoc :upload-result {:success? false :error (get-parsed-response)})))}))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
@@ -4,6 +4,7 @@
     [clojure.set :refer [union]]
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
     [org.broadinstitute.firecloud-ui.common.icons :as icons]
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.common.table-utils :as table-utils]
@@ -12,7 +13,6 @@
     [org.broadinstitute.firecloud-ui.page.workspace.data.copy-data-workspaces :as copy-data-workspaces]
     [org.broadinstitute.firecloud-ui.page.workspace.data.entity-selector :refer [EntitySelector]]
     [org.broadinstitute.firecloud-ui.page.workspace.data.import-data :as import-data]
-    [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
 
 
@@ -91,8 +91,8 @@
                                    (fn [maybe-uri]
                                      (if (string? maybe-uri)
                                        (if-let [parsed (common/parse-gcs-uri maybe-uri)]
-                                         [comps/GCSFilePreviewLink (assoc parsed
-                                                                     :gcs-uri maybe-uri)]
+                                         [dialog/GCSFilePreviewLink (assoc parsed
+                                                                      :gcs-uri maybe-uri)]
                                          maybe-uri)
                                        (table-utils/default-render maybe-uri)))})
                           attribute-keys))
@@ -118,22 +118,22 @@
       (when (:deleting? @state)
         [comps/Blocker {:banner "Deleting..."}])
       (when (:show-import? @state)
-        [comps/Dialog {:dismiss-self #(swap! state dissoc :show-import?)
-                       :width "80%"
-                       :content
-                       (react/create-element
-                         [DataImporter {:dismiss #(swap! state dissoc :show-import?)
-                                        :workspace-id (:workspace-id props)
-                                        :reload-data-tab (fn [entity-type]
-                                                           (swap! state dissoc :entity-list :entity-types)
-                                                           (react/call :load this entity-type))}])}])
+        [dialog/Dialog {:dismiss-self #(swap! state dissoc :show-import?)
+                        :width "80%"
+                        :content
+                        (react/create-element
+                          [DataImporter {:dismiss #(swap! state dissoc :show-import?)
+                                         :workspace-id (:workspace-id props)
+                                         :reload-data-tab (fn [entity-type]
+                                                            (swap! state dissoc :entity-list :entity-types)
+                                                            (react/call :load this entity-type))}])}])
       (when (:show-delete? @state)
-        [comps/Dialog
+        [dialog/Dialog
          {:dismiss-self #(swap! state dissoc :show-delete?)
           :width "80%"
           :content
           (react/create-element
-            [comps/OKCancelForm
+            [dialog/OKCancelForm
              {:header "Delete Entities"
               :dismiss-self #(swap! state dissoc :show-delete?)
               :content (react/create-element

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/delete_config.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/delete_config.cljs
@@ -1,0 +1,41 @@
+(ns org.broadinstitute.firecloud-ui.page.workspace.method-configs.delete-config
+  (:require
+    [dmohs.react :as react]
+    [org.broadinstitute.firecloud-ui.common :as common]
+    [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
+    [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
+    ))
+
+(react/defc DeleteDialog
+  {:render
+   (fn [{:keys [props state]}]
+     [dialog/Dialog
+      {:width 500
+       :dismiss-self (:dismiss-self props)
+       :content
+       (react/create-element
+         [dialog/OKCancelForm
+          {:header "Confirm Delete"
+           :dismiss-self (:dismiss-self props)
+           :content
+           (cond
+             (:error @state) [comps/ErrorViewer {:error (:error @state)}]
+             (:deleting? @state) [:div {:style {:backgroundColor "#fff" :padding "1em"}}
+                                  [comps/Spinner {:text "Deleting..."}]]
+             :else "Are you sure you want to delete this method configuration?")
+           :ok-button
+           [comps/Button
+            {:text "Delete"
+             :onClick
+             #(do (swap! state assoc :deleting? true :error nil)
+                  (endpoints/call-ajax-orch
+                    {:endpoint (endpoints/delete-workspace-method-config (:workspace-id props) (:config props))
+                     :on-done (fn [{:keys [success? get-parsed-response]}]
+                                (swap! state dissoc :deleting?)
+                                (if success?
+                                  ((:after-delete props))
+                                  (swap! state assoc :error (get-parsed-response))))}))}]}])}])
+   :component-did-mount
+   (fn []
+     (common/scroll-to-top 100))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/launch_analysis.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/launch_analysis.cljs
@@ -3,13 +3,11 @@
     [clojure.set :refer [union]]
     clojure.string
     [dmohs.react :as react]
-    [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
-    [org.broadinstitute.firecloud-ui.common.icons :as icons]
+    [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
-    [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
 
 
@@ -120,7 +118,7 @@
 (react/defc Page
   {:render
    (fn [{:keys [props state]}]
-     [comps/OKCancelForm
+     [dialog/OKCancelForm
       {:header "Launch Analysis"
        :dismiss-self (:on-cancel props)
        :content
@@ -166,12 +164,12 @@
    (fn [{:keys [props state]}]
      [:span {}
       (when (:display-modal? @state)
-        [comps/Dialog {:width "80%"
-                       :dismiss-self #(swap! state dissoc :display-modal?)
-                       :content (react/create-element
-                                 Page
-                                 (merge props
-                                  {:on-cancel #(swap! state dissoc :display-modal?)}))}])
+        [dialog/Dialog {:width "80%"
+                        :dismiss-self #(swap! state dissoc :display-modal?)
+                        :content (react/create-element
+                                   Page
+                                   (merge props
+                                     {:on-cancel #(swap! state dissoc :display-modal?)}))}])
       [comps/Button {:text "Launch Analysis..."
                      :disabled? (when (:disabled? props) "The workspace is locked")
                      :onClick #(swap! state assoc :display-modal? true)}]])})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/publish.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/publish.cljs
@@ -1,0 +1,57 @@
+(ns org.broadinstitute.firecloud-ui.page.workspace.method-configs.publish
+  (:require
+    [dmohs.react :as react]
+    [org.broadinstitute.firecloud-ui.common :as common]
+    [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
+    [org.broadinstitute.firecloud-ui.common.style :as style]
+    [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
+    ))
+
+
+(defn- render-modal-publish [state refs props]
+  (react/create-element
+    [dialog/OKCancelForm
+     {:header "Publish Method Configuration"
+      :content
+      (react/create-element
+        [:div {}
+         (when (:publishing? @state)
+           [comps/Blocker {:banner "Publishing Method Configuration..."}])
+         (style/create-form-label "Method Configuration Namespace")
+         (style/create-text-field {:style {:width "100%"} :ref "mcNamespace"
+                                   :defaultValue (get-in (:config props) ["namespace"])})
+         (style/create-form-label "Method Configuration Name")
+         (style/create-text-field {:style {:width "100%"} :ref "mcName"
+                                   :defaultValue (get-in (:config props) ["name"])})
+         (when (:error @state)
+           [comps/ErrorViewer {:error (:error @state)}])])
+      :dismiss-self (:dismiss-self props)
+      :ok-button
+      (react/create-element
+        [comps/Button {:text "Publish" :ref "publishButton"
+                       :onClick
+                       #(let [[ns n] (common/get-text refs "mcNamespace" "mcName")]
+                         (swap! state assoc :publishing? true :error nil)
+                         (endpoints/call-ajax-orch
+                           {:endpoint (endpoints/copy-method-config-to-repo (:workspace-id props) (:config props))
+                            :headers {"Content-Type" "application/json"}
+                            :payload  {:configurationNamespace ns,
+                                       :configurationName n,
+                                       :sourceNamespace (get-in (:config props) ["namespace"]),
+                                       :sourceName (get-in (:config props) ["name"])}
+                            :on-done  (fn [{:keys [success? get-parsed-response]}]
+                                        (swap! state dissoc :publishing?)
+                                        (if success?
+                                          ((:dismiss-self props))
+                                          (swap! state assoc :error (get-parsed-response))))}))}])}]))
+
+(react/defc PublishDialog
+  {:render
+   (fn [{:keys [props state refs]}]
+     [dialog/Dialog
+      {:width 500
+       :dismiss-self (:dismiss-self props)
+       :content (render-modal-publish state refs props)
+       :get-first-element-dom-node #(.getDOMNode (@refs "mcNamespace"))
+       :get-last-element-dom-node #(.getDOMNode (@refs "publishButton"))}])})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
@@ -4,6 +4,7 @@
     clojure.string
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
@@ -17,7 +18,7 @@
    (fn [{:keys [props state]}]
      [:div {}
       (when (:show-import-overlay? @state)
-        [comps/Dialog
+        [dialog/Dialog
          {:blocker? true
           :width "80%"
           :dismiss-self #(swap! state dissoc :show-import-overlay?)
@@ -91,7 +92,7 @@
         [MethodConfigEditor {:config (:selected-method-config @state)
                              :workspace-id (:workspace-id props)
                              :on-submission-success (:on-submission-success props)
-                             :on-rm (fn [] (swap! state dissoc :selected-method-config))}]
+                             :after-delete #(swap! state dissoc :selected-method-config)}]
         [MethodConfigurationsList
          {:workspace-id (:workspace-id props)
           ;TODO: For both callbacks - rename config to config-id and follow the workspace-id pattern

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/common.cljs
@@ -1,7 +1,5 @@
 (ns org.broadinstitute.firecloud-ui.page.workspace.monitor.common
   (:require
-    [dmohs.react :as react]
-    [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.common.icons :as icons]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     ))
@@ -26,9 +24,9 @@
         [:span {:style {:backgroundColor (:running-blue style/colors) :position "relative"
                         :width 16 :height 16 :display "inline-block" :borderRadius 3
                         :verticalAlign "middle" :marginTop -4 :marginRight 4}}
-         (style/center {} [comps/RunningIcon {:size 12}])]
+         (style/center {} [icons/RunningIcon {:size 12}])]
         :else
         [:span {:style {:backgroundColor (:exception-red style/colors) :position "relative"
                         :width 16 :height 16 :display "inline-block" :borderRadius 3
                         :verticalAlign "middle" :marginTop -4 :marginRight 4}}
-         (style/center {} [comps/ExceptionIcon {:size 12}])]))
+         (style/center {} [icons/ExceptionIcon {:size 12}])]))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
@@ -18,9 +18,9 @@
         :else (:exception-red style/colors)))
 
 (defn- icon-for-submission [submission]
-  (cond (= "Submitted" (submission "status")) [comps/RunningIcon {:size 36}]
-        (moncommon/all-success? submission) [comps/CompleteIcon {:size 36}]
-        :else [comps/ExceptionIcon {:size 36}]))
+  (cond (= "Submitted" (submission "status")) [icons/RunningIcon {:size 36}]
+        (moncommon/all-success? submission) [icons/CompleteIcon {:size 36}]
+        :else [icons/ExceptionIcon {:size 36}]))
 
 
 (react/defc WorkflowsTable

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/acl_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/acl_editor.cljs
@@ -4,6 +4,7 @@
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
     ))
 
@@ -30,7 +31,7 @@
     acl-map))
 
 (defn- render-acl-content [props state this]
-  [comps/OKCancelForm
+  [dialog/OKCancelForm
    {:header
     (let [workspace-id (:workspace-id props)]
       (str "Permissions for " (:namespace workspace-id) "/" (:name workspace-id)))
@@ -74,7 +75,7 @@
 (react/defc AclEditor
   {:render
    (fn [{:keys [props state this]}]
-     [comps/Dialog
+     [dialog/Dialog
       {:width "50%"
        :dismiss-self (:dismiss-self props)
        :content

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
@@ -11,7 +11,6 @@
     [org.broadinstitute.firecloud-ui.page.workspace.summary.acl-editor :refer [AclEditor]]
     [org.broadinstitute.firecloud-ui.page.workspace.summary.attribute-editor :refer [AttributeViewer]]
     [org.broadinstitute.firecloud-ui.page.workspace.summary.workspace-cloner :refer [WorkspaceCloner]]
-    [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
 
 
@@ -45,9 +44,9 @@
                                   (when (= status "Running")
                                     (str " (" (get-in ws ["workspaceSubmissionStats" "runningSubmissionsCount"]) ")")))
                           :icon (case status
-                                  "Complete" [comps/CompleteIcon {:size 36}]
-                                  "Running" [comps/RunningIcon {:size 36}]
-                                  "Exception" [comps/ExceptionIcon {:size 36}])
+                                  "Complete" [icons/CompleteIcon {:size 36}]
+                                  "Running" [icons/RunningIcon {:size 36}]
+                                  "Exception" [icons/ExceptionIcon {:size 36}])
                           :color (style/color-for-status status)}]
       [comps/SidebarButton {:style :light :margin :top :color :button-blue
                             :text "View attributes" :icon :document

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/workspace_cloner.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/workspace_cloner.cljs
@@ -4,6 +4,7 @@
     [dmohs.react :as react]
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
     ))
@@ -11,10 +12,10 @@
 (react/defc WorkspaceCloner
   {:render
    (fn [{:keys [props refs state this]}]
-     [comps/Dialog {:width 400 :dismiss-self (:dismiss props)
+     [dialog/Dialog {:width 400 :dismiss-self (:dismiss props)
                     :content
                     (react/create-element
-                      [comps/OKCancelForm
+                      [dialog/OKCancelForm
                        {:header "Clone Workspace to:"
                         :dismiss-self (:dismiss props)
                         :content

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -4,6 +4,8 @@
     [dmohs.react :as react]
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
+    [org.broadinstitute.firecloud-ui.common.icons :as icons]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.common.table :as table]
@@ -15,7 +17,7 @@
 
 (defn- render-modal [state refs nav-context]
   (react/create-element
-    [comps/OKCancelForm
+    [dialog/OKCancelForm
      {:header "Create New Workspace"
       :content
       (react/create-element
@@ -62,9 +64,9 @@
                        :position "absolute" :top 0 :right 0 :bottom 0 :left 2}}]
         (style/center {}
           (case status
-            "Complete"  [comps/CompleteIcon]
-            "Running"   [comps/RunningIcon]
-            "Exception" [comps/ExceptionIcon]))]))})
+            "Complete" [icons/CompleteIcon]
+            "Running" [icons/RunningIcon]
+            "Exception" [icons/ExceptionIcon]))]))})
 
 
 (react/defc WorkspaceCell
@@ -181,7 +183,7 @@
            selected-ws-id (get-workspace-id-from-nav-segment (:segment nav-context))]
        [:div {}
         (when (:overlay-shown? @state)
-          [comps/Dialog
+          [dialog/Dialog
            {:width 500
             :dismiss-self #(swap! state dissoc :overlay-shown?)
             :content (render-modal state refs nav-context)


### PR DESCRIPTION
Also used this viewer in the publish and delete dialogs in the method config editor, in order to test more functionality.  The layouts may not be perfect for those components, but since this story is only concerned with the file import, I'm leaving future improvement for another story.

Also moved a bunch of stuff around.  Sorry about that.