### PR TITLE
Refresh current tab by clicking it

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -12,7 +12,7 @@
 (react/defc WorkspaceDetails
   {:render
    (fn [{:keys [props refs]}]
-     [:div {}
+     [:div {:style {:margin "0 -1em"}}
       [comps/TabBar {:ref "tab-bar"
                      :items
                      [{:text "Summary"

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
@@ -52,7 +52,14 @@
 
 
 (react/defc SubmissionsList
-  {:render
+  {:reload
+   (fn [{:keys [state this]}]
+     (swap! state dissoc :server-response)
+     (react/call :load-submissions this))
+   :get-initial-state
+   (fn []
+     {:loading? false})
+   :render
    (fn [{:keys [props state]}]
      (let [server-response (:server-response @state)
            {:keys [submissions error-message]} server-response]
@@ -61,19 +68,21 @@
          [:div {:style {:textAlign "center"}} [comps/Spinner {:text "Loading analyses..."}]]
          error-message (style/create-server-error-message error-message)
          :else
-         [:div {:style {:margin "0 -2em"}}
-          (render-submissions-table submissions (:on-submission-clicked props))])))
+         (render-submissions-table submissions (:on-submission-clicked props)))))
    :component-did-mount
     (fn [{:keys [this]}]
       (react/call :load-submissions this))
    :load-submissions
    (fn [{:keys [props state]}]
-     (endpoints/call-ajax-orch
-       {:endpoint (endpoints/list-submissions (:workspace-id props))
-        :on-done (fn [{:keys [success? status-text get-parsed-response]}]
-                   (swap! state assoc :server-response (if success?
-                                                         {:submissions (get-parsed-response)}
-                                                         {:error-message status-text})))}))})
+     (when-not (:loading? @state)
+       (swap! state assoc :loading true)
+       (endpoints/call-ajax-orch
+         {:endpoint (endpoints/list-submissions (:workspace-id props))
+          :on-done (fn [{:keys [success? status-text get-parsed-response]}]
+                     (swap! state assoc :server-response (if success?
+                                                           {:submissions (get-parsed-response)}
+                                                           {:error-message status-text}))
+                     (swap! state assoc :loading false))})))})
 
 
 (react/defc Page
@@ -82,14 +91,17 @@
      {:selected-submission-id (:initial-submission-id props)})
    :render
    (fn [{:keys [props state]}]
-     [:div {:style {:margin "2em"}}
+     [:div {:style {:padding "1em"}}
       (if-let [sid (:selected-submission-id @state)]
         [submission-details/Page {:workspace-id (:workspace-id props) :submission-id sid}]
-        [SubmissionsList {:workspace-id (:workspace-id props)
+        [SubmissionsList {:ref "submissions-list"
+                          :workspace-id (:workspace-id props)
                           :on-submission-clicked #(swap! state assoc :selected-submission-id %)}])])
    :component-will-receive-props
-   (fn [{:keys [state]}]
-     (swap! state dissoc :selected-submission-id))})
+   (fn [{:keys [state refs]}]
+     (if (:selected-submission-id @state)
+       (swap! state dissoc :selected-submission-id)
+       (react/call :reload (@refs "submissions-list"))))})
 
 
 (defn render [workspace-id & [submission-id]]


### PR DESCRIPTION
Used :component-will-receive-props to accomplish this, however some tabs were also triggering reloads on :component-did-update, which was causing multiple loads.  So I added a simple locking mechanism to each tab to prevent simultaneous data load calls.  This is a bit of a hack; a future improvement would be to modify the TabBar component to trigger a specific reload rather than relying on React lifecycle methods.

Also fixed an issue with the tab bar's margins, and standardized some padding and the centering of the "loading..." spinner across all tabs.