### PR TITLE
DSDEEPB-1911: ensure we are working with a number when calling toFixed

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -116,6 +116,6 @@
 (defn format-filesize [bytes]
   (letfn [(loop [b n]
             (if (< b 1000)
-              (str (.toFixed b 2) " " (nth ["B" "KB" "MB" "GB" "TB" "PB" "EB" "ZB" "YB"] n))
+              (str (.toFixed (js/parseFloat b) 2) " " (nth ["B" "KB" "MB" "GB" "TB" "PB" "EB" "ZB" "YB"] n))
               (loop (/ b 1000) (inc n))))]
     (loop bytes 0)))


### PR DESCRIPTION
when we first retrieve metadata from GCS, Google's json lists file sizes as strings:
```
{
  ...
 "size": "102"
  ...
}
```

If the size was large enough, the loop executed at least once, and we divided the string by 1000, which allowed JS to magically turn the string into a number.

But, if the size was small enough that we attempted to call toFixed() in the first iteration of the loop, we threw an error - String.toFixed doesn't exist. 

Fix: always ensure it's a float. In subsequent iterations of the loop, this is overkill, but it feels safe.