### PR TITLE
Cleaned up use of data tables throughout UI

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
@@ -9,77 +9,39 @@
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
+    [org.broadinstitute.firecloud-ui.page.workspace.data.entity-selector :refer [EntitySelector]]
     ))
 
-(defn- entity-listing [state props this from-ws]
-  [:div {}
-   [:h3 {}
-    "Select entities to copy from "
-    (get-in from-ws ["workspace" "namespace"])
-    "/"
-    (get-in from-ws ["workspace" "name"])
-    [:span {:style {:marginLeft "1.5em"}}
-     (style/create-link
-       #((:back props))
-       (icons/font-icon {:style {:fontSize "70%" :marginRight "0.5em"}} :angle-left)
-       "Choose a different workspace")]]
-   (let [attribute-keys (apply union (map #(set (keys (% "attributes")))
-                                          (filter #(= (% "entityType")
-                                                      (:selected-entity-type @state))
-                                                  (:entity-list props))))]
-     [table/Table
-      {:key (:selected-entity-type @state)
-       :empty-message "There are no entities to display."
-       :toolbar (fn [built-in]
-                  [:div {}
-                   [:div {:style {:float "left"}} built-in]
-                   (when (pos? (count (:selected-entities @state)))
-                     [:div {:style {:float "right"}}
-                      [comps/Button {:text "Copy" :onClick #(react/call :perform-copy this)}]])
-                   (common/clear-both)])
-       :columns (concat
-                  [{:starting-width 40 :resizable? false :sort-by :none :filter-by :none
-                    :content-renderer
-                    (fn [entity]
-                      (when (contains? (:selected-entities @state) entity)
-                        (icons/font-icon {:style {:color (:success-green style/colors)}} :status-done)))}
-                   {:header "Entity Type" :starting-width 100}
-                   {:header "Entity Name" :starting-width 100
-                    :content-renderer
-                    (fn [entity]
-                      (style/create-link
-                        #(swap! state update-in [:selected-entities]
-                          (if (contains? (:selected-entities @state) entity) disj conj) entity)
-                        (entity "name")))}]
-                  (map (fn [k] {:header k :starting-width 100}) attribute-keys))
-       :filters (mapv (fn [key] {:text key :pred #(= key (% "entityType"))})
-                      (:entity-types props))
-       :selected-filter-index (.indexOf (to-array (:entity-types props))
-                                        (:selected-entity-type @state))
-       :on-filter-change #(swap! state assoc :selected-entity-type (nth (:entity-types props) %))
-       :data (:entity-list props)
-       :->row (fn [m]
-                (concat
-                 [m
-                  (m "entityType")
-                  m]
-                 (map (fn [k] (get-in m ["attributes" k])) attribute-keys)))}])])
 
 (react/defc EntitiesList
-  {:get-initial-state
-   (fn [{:keys [props]}]
-     {:selected-entity-type (or (:initial-entity-type props) (first (:entity-types props)))
-      :selected-entities #{}})
-   :render
-   (fn [{:keys [props state this]}]
+  {:render
+   (fn [{:keys [props state this refs]}]
      (let [from-ws (:selected-from-workspace props)]
        [:div {:style {:margin "1em"}}
         (when (:copying? @state)
           [comps/Blocker {:banner "Copying..."}])
-        (entity-listing state props this from-ws)]))
+        [EntitySelector {:ref "EntitySelector"
+                         :left-text (str "Entities in " (get-in from-ws ["workspace" "namespace"])
+                                      "/" (get-in from-ws ["workspace" "name"]))
+                         :right-text "To be imported"
+                         :entities (:entity-list props)}]
+        [:div {:style {:textAlign "center"}}
+         (when (:selection-error @state)
+           [:div {:style {:marginTop "0.5em"}}
+            "Please select at least one entity to copy"])
+         (when (:server-error @state)
+           [:div {:style {:marginTop "0.5em"}}
+            [comps/ErrorViewer {:error (:server-error @state)}]])
+         [:div {:style {:marginTop "1em"}}
+          [comps/Button {:text "Copy"
+                         :onClick #(let [selected (react/call :get-selected-entities (@refs "EntitySelector"))]
+                                     (if (empty? selected)
+                                       (swap! state assoc :selection-error true)
+                                       (react/call :perform-copy this selected)))}]]]]))
    :perform-copy
-   (fn [{:keys [props state]}]
-     (let [grouped-entities (group-by #(% "entityType") (:selected-entities @state))]
+   (fn [{:keys [props state]} selected]
+     (swap! state dissoc :selection-error :server-error)
+     (let [grouped-entities (group-by #(% "entityType") selected)]
        (swap! state assoc :copying? true :remaining (count grouped-entities))
        (doseq
          [[type list] grouped-entities]
@@ -90,13 +52,13 @@
                       :entityType type
                       :entityNames (map #(% "name") list)}
             :headers {"Content-Type" "application/json"}
-            :on-done (fn [{:keys [success? status-text]}]
+            :on-done (fn [{:keys [success? get-parsed-response]}]
                        (swap! state update-in [:remaining] dec)
                        (when (zero? (:remaining @state))
-                         (swap! state assoc :copying? false :selected-entities #{})
+                         (swap! state assoc :copying? false)
                          ((:reload-data-tab props) type))
                        (when-not success?
-                         (swap! state assoc :copy-error status-text)))}))))})
+                         (swap! state assoc :server-error (get-parsed-response))))}))))})
 
 
 (react/defc Page

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/launch_analysis.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/launch_analysis.cljs
@@ -3,6 +3,7 @@
     [clojure.set :refer [union]]
     clojure.string
     [dmohs.react :as react]
+    [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
     [org.broadinstitute.firecloud-ui.common.style :as style]
@@ -31,8 +32,7 @@
                              :methodConfigurationName (:name config-id)
                              :entityType (:type entity-id)
                              :entityName (:name entity-id)}
-                            (when-not (clojure.string/blank? expression) {:expression expression}))
-             on-success (:on-success props)]
+                            (when-not (clojure.string/blank? expression) {:expression expression}))]
          (swap! state assoc :launching? true)
          (endpoints/call-ajax-orch
            {:endpoint (endpoints/create-submission (:workspace-id props))
@@ -41,8 +41,8 @@
             :on-done (fn [{:keys [success? get-parsed-response status-text]}]
                        (swap! state dissoc :launching?)
                        (if success?
-                         (on-success ((get-parsed-response) "submissionId"))
-                         (js/alert (str "Launch failed: " status-text))))}))
+                         ((:on-success props) ((get-parsed-response) "submissionId"))
+                         ((:on-error props) (get-parsed-response))))}))
        (js/alert "Please select an entity.")))})
 
 
@@ -54,7 +54,7 @@
        (if (contains? (set types) root)
          (let [entity (first (filter #(= root (% "entityType")) (:entities props)))]
            ((:entity-selected props) (entity->id entity))
-           {:selected-entity (first (filter #(= root (% "entityType")) (:entities props)))
+           {:selected-entity entity
             :selected-entity-type root})
          {:selected-entity-type (first types)})))
    :render
@@ -63,45 +63,21 @@
       (style/create-form-label "Select Entity")
       [:div {:style {:backgroundColor "#fff" :border (str "1px solid " (:line-gray style/colors))
                      :padding "1em" :marginBottom "0.5em"}}
-       (let [attribute-keys (apply
-                             union
-                             (map #(set (keys (% "attributes")))
-                                  (filter #(= (% "entityType") (:selected-entity-type @state))
-                                          (:entities props))))
-             types (:entity-types props)
-             root (:root-entity-type props)
-             ordered-types (if (contains? (set types) root)
-                             (cons root (remove #(= % root) types))
-                             types)]
-         [table/Table
-          {:key (:selected-entity-type @state)
-           :empty-message "No entities available."
-           :columns (concat
-                     [{:header "" :starting-width 40 :resizable? false :reorderable? false
-                       :sort-by :none :filter-by :none
-                       :content-renderer
-                       (fn [data]
-                         [:input {:type "radio"
-                                  :checked (identical? data (:selected-entity @state))
-                                  :onChange #(do (swap! state assoc :selected-entity data)
-                                                 ((:entity-selected props) (entity->id data)))}])}
-                      {:header "Entity Type" :starting-width 100}
-                      {:header "Entity Name" :starting-width 100}]
-                     (map (fn [k] {:header k :starting-width 100}) attribute-keys))
-           :filters (mapv (fn [key] {:text key :pred #(= key (% "entityType"))}) ordered-types)
-           :selected-filter-index (.indexOf (to-array ordered-types)
-                                            (:selected-entity-type @state))
-           :on-filter-change #(swap! state assoc
-                                     :selected-entity-type (nth ordered-types %))
-           :data (:entities props)
-           :->row (fn [m]
-                    (concat
-                     [m
-                      (m "entityType")
-                      (m "name")]
-                     (map (fn [k] (get-in m ["attributes" k])) attribute-keys)))}])]
+       [:div {:style {:marginBottom "1em" :fontSize "140%"}}
+        (str "Selected: "
+          (if-let [e (:selected-entity @state)]
+            (str (e "name") " (" (e "entityType") ")")
+            "None"))]
+       [table/EntityTable
+        {:entities (:entities props)
+         :entity-types (:entity-types props)
+         :entity-name-renderer (fn [entity]
+                                 (style/create-link
+                                   #(do (swap! state assoc :selected-entity entity)
+                                        ((:entity-selected props) (entity->id entity)))
+                                   (entity "name")))}]]
       (style/create-form-label "Define Expression")
-      (let [disabled (= (:root-entity-type props) (:selected-entity-type @state))]
+      (let [disabled (= (:root-entity-type props) (get-in @state [:selected-entity "entityType"]))]
         (style/create-text-field {:placeholder "leave blank for default"
                                   :style {:width "100%"
                                           :backgroundColor (when disabled
@@ -132,10 +108,7 @@
            (zero? (count @state))
            (style/create-message-well "No data found.")
            :else
-           [LaunchForm {:on-success (:on-success props)
-                        :config-id (:config-id props)
-                        :workspace-id (:workspace-id props)
-                        :entities entities
+           [LaunchForm {:entities entities
                         :entity-types entity-types
                         :root-entity-type (:root-entity-type props)
                         :entity-selected #(swap! state assoc :selected-entity-id %)
@@ -145,9 +118,11 @@
                        {:entity-id (:selected-entity-id @state)
                         :expression (when-not (= (:root-entity-type props)
                                                  (:type (:selected-entity-id @state)))
-                                      (:selected-expression @state))})]}])
+                                      (:selected-expression @state))
+                        :on-error #(swap! state assoc :launch-server-error %)})]}])
    :component-did-mount
    (fn [{:keys [props state]}]
+     (common/scroll-to-top 100)
      (endpoints/call-ajax-orch
        {:endpoint (endpoints/get-entities-by-type (:workspace-id props))
         :on-done (fn [{:keys [success? status-text get-parsed-response]}]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
@@ -214,7 +214,7 @@
      (cond (and (:loaded-config @state) (contains? @state :locked?))
            (render-display state refs (:loaded-config @state) (:editing? @state) props)
            (:error @state) (style/create-server-error-message (:error @state))
-           :else [comps/Spinner {:text "Loading Method Configuration..."}]))
+           :else [:div {:style {:textAlign "center"}} [comps/Spinner {:text "Loading Method Configuration..."}]]))
    :component-did-mount
    (fn [{:keys [state props refs this]}]
      (endpoints/call-ajax-orch


### PR DESCRIPTION
* Created table/EntityTable, used in the data tab and launch analysis dialog
* Redesigned copy data from workspace to use EntitySelector instead
* Redesigned launch analysis dialog to not use radio button column
* Data tables now also strip out the entity name from references to other entities

Other notes:
* Some rework to the table regarding default properties: using the `(or (:propname props) default)` pattern instead of `:get-default-props` makes it a little cleaner to override them.  With `:get-default-props` passing a `nil` value counts as overriding the default.
* EntitySelector was just too different to effectively merge.