### PR TITLE
Remove oauth requirements from the ui proxy

### DIFF
--- a/src/docker/run-apache.sh
+++ b/src/docker/run-apache.sh
@@ -49,13 +49,6 @@ LOCATION_DIRECTIVES=$(cat << EOF
     ProxyPass ${ORCH_URL_ROOT}
     ProxyPassReverse ${ORCH_URL_ROOT}
   </Location>
-
-  <Location "/service/api">
-    AuthType oauth20
-    Require valid-user
-    ProxyPass ${ORCH_URL_ROOT}/api
-    ProxyPassReverse ${ORCH_URL_ROOT}/api
-  </Location>
 EOF
 )
 


### PR DESCRIPTION
See https://broadinstitute.atlassian.net/browse/DSDEEPB-1832

With oauth in front of orchestration, it is not needed in front of UI.