### PR TITLE
Fixed error messages and cancel bug in workspace clone dialog

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -241,16 +241,22 @@
        (when-let [error (:error props)]
          (let [[source status-code causes stack-trace message]
                (map error ["source" "statusCode" "causes" "stackTrace" "message"])]
-           [:div {:style {:textAlign "initial"}}
-            [:div {}
-             [:span {:style {:paddingRight "1ex"}}
-              (icons/font-icon {:style {:color (:exception-red style/colors)}}
-                :status-warning-triangle)]
-             (str "Error " status-code ": " message)]
-            (when source [:div {} "Source: " source])
-            (when-not (empty? causes)
+           (if-let [expected-msg (get-in props [:expect status-code])]
+             [:div {}
+              [:span {:style {:paddingRight "1ex"}}
+               (icons/font-icon {:style {:color (:exception-red style/colors)}}
+                 :status-warning-triangle)]
+              (str "Error: " expected-msg)]
+             [:div {:style {:textAlign "initial"}}
               [:div {}
-               [:div {} (str "Cause" (when (> (count causes) 1) "s") ":")]
-               (map (fn [cause] [CauseViewer cause]) causes)])
-            (when-not (empty? stack-trace)
-              [StackTraceViewer {:lines stack-trace}])])))}))
+               [:span {:style {:paddingRight "1ex"}}
+                (icons/font-icon {:style {:color (:exception-red style/colors)}}
+                  :status-warning-triangle)]
+               (str "Error " status-code ": " message)]
+              (when source [:div {} "Source: " source])
+              (when-not (empty? causes)
+                [:div {}
+                 [:div {} (str "Cause" (when (> (count causes) 1) "s") ":")]
+                 (map (fn [cause] [CauseViewer cause]) causes)])
+              (when-not (empty? stack-trace)
+                [StackTraceViewer {:lines stack-trace}])]))))}))

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/input.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/input.cljs
@@ -19,6 +19,7 @@
          fails)))
    :render
    (fn [{:keys [state props refs]}]
+     (assert (not (empty? (:predicates props))) "No predicates for input/TextField")
      (style/create-text-field {:ref "textfield"
                                :style (merge (:style props)
                                         (when (:invalid @state)

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
@@ -38,7 +38,8 @@
                    :dismiss-self #(swap! state dissoc :editing-acl?)
                    :update-owners #(swap! state update-in [:server-response :workspace] assoc "owners" %)}])
      (when (:cloning? @state)
-       [WorkspaceCloner {:on-success (fn [namespace name]
+       [WorkspaceCloner {:dismiss #(swap! state dissoc :cloning?)
+                         :on-success (fn [namespace name]
                                        (swap! state dissoc :cloning?)
                                        (nav/navigate nav-context (str namespace ":" name)))
                          :workspace-id (:workspace-id props)}])

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/workspace_cloner.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/workspace_cloner.cljs
@@ -5,6 +5,7 @@
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
+    [org.broadinstitute.firecloud-ui.common.input :as input]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
     [org.broadinstitute.firecloud-ui.utils :as utils]
@@ -14,53 +15,52 @@
   {:render
    (fn [{:keys [props refs state this]}]
      [dialog/Dialog {:width 400 :dismiss-self (:dismiss props)
-                    :content
-                    (react/create-element
-                      [dialog/OKCancelForm
-                       {:header "Clone Workspace to:"
-                        :dismiss-self (:dismiss props)
-                        :content
-                        (react/create-element
-                          [:div {}
-                           (when (:working? @state)
-                             [comps/Blocker {:banner "Cloning..."}])
-                           (style/create-form-label "Google Project")
-                           (style/create-text-field {:ref "namespace"
-                                                     :style {:width "100%"}
-                                                     :defaultValue (get-in props [:workspace-id :namespace])
-                                                     :placeholder "Required"
-                                                     :onChange #(swap! state dissoc :error)})
-                           (style/create-form-label "Name")
-                           (style/create-text-field {:ref "name"
-                                                     :style {:width "100%"}
-                                                     :defaultValue (get-in props [:workspace-id :name])
-                                                     :placeholder "Required"
-                                                     :onChange #(swap! state dissoc :error)})
-                           (when (:error @state)
-                             [:div {:style {:color (:exception-red style/colors)}}
-                              (:error @state)])])
-                        :ok-button
-                        (react/create-element
-                          [comps/Button {:text "OK" :ref "okButton"
-                                         :onClick #(react/call :do-clone this)}])}])
-                    :get-first-element-dom-node #(.getDOMNode (@refs "namespace"))
-                    :get-last-element-dom-node #(.getDOMNode (@refs "okButton"))}])
+                     :content
+                     (react/create-element
+                       [dialog/OKCancelForm
+                        {:header "Clone Workspace to:"
+                         :dismiss-self (:dismiss props)
+                         :content
+                         (react/create-element
+                           [:div {}
+                            (when (:working? @state)
+                              [comps/Blocker {:banner "Cloning..."}])
+                            (style/create-form-label "Google Project")
+                            [input/TextField {:ref "namespace"
+                                              :style {:width "100%"}
+                                              :defaultValue (get-in props [:workspace-id :namespace])
+                                              :placeholder "Required"
+                                              :predicates [(input/nonempty "Google Project")]}]
+                            (style/create-form-label "Name")
+                            [input/TextField {:ref "name"
+                                              :style {:width "100%"}
+                                              :defaultValue (get-in props [:workspace-id :name])
+                                              :placeholder "Required"
+                                              :predicates [(input/nonempty "Workspace name")]}]
+                            (style/create-validation-error-message (:validation-error @state))
+                            [comps/ErrorViewer {:error (:error @state)
+                                                :expect {409 "A workspace with this name already exists in this project"}}]])
+                         :ok-button
+                         (react/create-element
+                           [comps/Button {:text "OK" :ref "okButton"
+                                          :onClick #(react/call :do-clone this)}])}])
+                     :get-first-element-dom-node #(.getDOMNode (@refs "namespace"))
+                     :get-last-element-dom-node #(.getDOMNode (@refs "okButton"))}])
    :component-did-mount
    (fn []
      (common/scroll-to-top 100))
    :do-clone
    (fn [{:keys [props refs state]}]
-     (let [[namespace name] (common/get-text refs "namespace" "name")]
-       (if (some blank? [namespace name])
-         (swap! state assoc :error "All fields required")
-         (do
-           (swap! state assoc :working? true)
-           (endpoints/call-ajax-orch
-             {:endpoint (endpoints/clone-workspace (:workspace-id props))
-              :payload {:namespace namespace :name name}
-              :headers {"Content-Type" "application/json"}
-              :on-done (fn [{:keys [success? status-text]}]
-                         (swap! state dissoc :working?)
-                         (if success?
-                           ((:on-success props) namespace name)
-                           (swap! state assoc :error status-text)))})))))})
+     (if-let [fails (input/validate refs "namespace" "name")]
+       (swap! state assoc :validation-error fails)
+       (let [[namespace name] (input/get-text refs "namespace" "name")]
+         (swap! state assoc :working? true :validation-error nil :error nil)
+         (endpoints/call-ajax-orch
+           {:endpoint (endpoints/clone-workspace (:workspace-id props))
+            :payload {:namespace namespace :name name}
+            :headers {"Content-Type" "application/json"}
+            :on-done (fn [{:keys [success? get-parsed-response]}]
+                       (swap! state dissoc :working?)
+                       (if success?
+                         ((:on-success props) namespace name)
+                         (swap! state assoc :error (get-parsed-response))))}))))})


### PR DESCRIPTION
DSDEEPB-1973 was a simple oversight.

For DSDEEPB-1918, the error viewer was extended to take a map of "expected" error codes with associated messages, which is used for the 409 (conflict).