### PR TITLE
Add User Profile link and nav context

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -119,3 +119,7 @@
               (str (.toFixed (js/parseFloat b) 2) " " (nth ["B" "KB" "MB" "GB" "TB" "PB" "EB" "ZB" "YB"] n))
               (loop (/ b 1000) (inc n))))]
     (loop bytes 0)))
+
+(defn parse-profile [unparsed-profile]
+  (let [unparsed-values (get unparsed-profile "keyValuePairs")]
+    (into {} (map (fn [m] [(keyword (m "key")) (m "value")]) unparsed-values))))

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
@@ -52,9 +52,6 @@
 (defn create-form-label [text]
   [:div {:style {:marginBottom "0.16667em" :fontSize "88%"}} text])
 
-(defn create-hint [text]
-  [:em {:style {:fontSize "69%"}} text])
-
 (defn create-text-field [props]
   [:input (deep-merge {:type "text" :style input-text-style} props)])
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -539,15 +539,15 @@
      "/profile"
      {:on-done on-done
      :canned-response
-     {:status (rand-nth [200 200 500]) :delay-ms (rand-int 2000)
+     {:status 200 :delay-ms (rand-int 2000)
       :responseText
       (utils/->json-string
        {:userId "55"
         :keyValuePairs
         (map (fn [[k v]] {:key k :value v})
-             {:isActive true :name "John Doe" :contactEmail "jdoe@example.com"
+             {:isRegistrationComplete "true" :name "John Doe" :email "jdoe@example.com"
               :googleProjectIds ["14" "7"] :institution "Broad Institute"
-              :piName "Jane Doe"})})}}
+              :pi "Jane Doe"})})}}
      :service-prefix "/service/register"))
   ([k on-done]
    (utils/ajax-orch

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/profile.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/profile.cljs
@@ -2,6 +2,7 @@
   (:require
    clojure.string
    [dmohs.react :as react]
+   [org.broadinstitute.firecloud-ui.common :as common]
    [org.broadinstitute.firecloud-ui.common.components :as components]
    [org.broadinstitute.firecloud-ui.common.style :as style]
    [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
@@ -13,25 +14,31 @@
   {:get-values
    (fn [{:keys [state]}]
      (reduce-kv (fn [r k v] (assoc r k (clojure.string/trim v))) {} (:values @state)))
-   :get-initial-state
-   (fn [{:keys [props]}]
-     {:values (:initial-values props)})
    :render
-   (fn [{:keys [this]}]
-     [:div {}
-      (react/call :render-field this :name "Full Name:")
-      (react/call :render-field this :email "Contact Email:")
-      (react/call :render-field this :institution "Institutional Affiliation:")
-      (react/call :render-field this :pi "Principal Investigator:")])
+   (fn [{:keys [state this]}]
+     (cond (:error-message @state) (style/create-server-error-message (:error-message @state))
+           (:values @state) [:div {}
+                             (react/call :render-field this :name "Full Name:")
+                             (react/call :render-field this :email "Contact Email:")
+                             (react/call :render-field this :institution "Institutional Affiliation:")
+                             (react/call :render-field this :pi "Principal Investigator:")]
+           :else [components/Spinner {:text "Loading User Profile..."}]))
    :render-field
    (fn [{:keys [state]} key label]
      [:div {}
       [:label {}
-       [:span {:style {:fontSize "88%"}} label] [:br]
+       (style/create-form-label label)
        (style/create-text-field
-        {:style {:marginTop "0.167em" :width "30ex"}
-         :value (get-in @state [:values key])
-         :onChange #(swap! state assoc-in [:values key] (-> % .-target .-value))})]])})
+         {:style {:marginTop "0.167em" :width "30ex"}
+          :value (get-in @state [:values key])
+          :onChange #(swap! state assoc-in [:values key] (-> % .-target .-value))})]])
+   :component-did-mount
+   (fn [{:keys [state]}]
+     (endpoints/profile-get
+       (fn [{:keys [success? status-text get-parsed-response]}]
+         (if success?
+           (swap! state assoc :values (common/parse-profile (get-parsed-response)))
+           (swap! state assoc :error-message status-text)))))})
 
 
 (react/defc Page
@@ -41,7 +48,7 @@
        [:div {:style {:marginTop "2em"}}
         [:h2 {} (if new? "New User Registration" "Profile")]
         [:div {:style {:marginBottom "1em"}}
-         [Form {:ref "form" :initial-values (:initial-values @state)}]]
+         [Form {:ref "form"}]]
         (when-not (or (:in-progress? @state) (:done? @state))
           [components/Button {:text (if new? "Register" "Save") 
                               :onClick #(react/call :save this)}])


### PR DESCRIPTION
**DO NOT MERGE**: I would like to squash this when the time comes.

This PR:
* Common method for parsing the user profile info from orchestration.
* Provide a top-level nav structure for routes and route handlers
* Populate the user profile page with pre-existing information
* Show the user's name in the top right corner of the page for easy navigation.

Lots of kudos to @MattPutnam for his clojure map-deconvolution expertise.