### PR TITLE
Move profile endpoints under /service/register

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -536,8 +536,8 @@
 (defn profile-get
   ([on-done]
    (utils/ajax-orch
-    "/profile"
-    {:on-done on-done
+     "/profile"
+     {:on-done on-done
      :canned-response
      {:status (rand-nth [200 200 500]) :delay-ms (rand-int 2000)
       :responseText
@@ -547,20 +547,23 @@
         (map (fn [[k v]] {:key k :value v})
              {:isActive true :name "John Doe" :contactEmail "jdoe@example.com"
               :googleProjectIds ["14" "7"] :institution "Broad Institute"
-              :piName "Jane Doe"})})}}))
+              :piName "Jane Doe"})})}}
+     :service-prefix "/service/register"))
   ([k on-done]
    (utils/ajax-orch
-    (str "/profile/" (name k))
-    {:on-done on-done
+     (str "/profile/" (name k))
+     {:on-done on-done
      :canned-response
      {:status (rand-nth [200 200 500]) :delay-ms (rand-int 2000)
-      :responseText (utils/->json-string {:userId "55" :keyValuePair {:key k :value "asdf"}})}})))
+      :responseText (utils/->json-string {:userId "55" :keyValuePair {:key k :value "asdf"}})}}
+     :service-prefix "/service/register")))
 
 
 (defn profile-set [k v on-done]
   (utils/ajax-orch
-   (str "/profile/" (name k))
-   {:method :post
+    (str "/profile/" (name k))
+    {:method :post
     :data v
     :on-done on-done
-    :canned-response {:status (rand-nth [200 200 500]) :delay-ms (rand-int 2000)}}))
+    :canned-response {:status (rand-nth [200 200 500]) :delay-ms (rand-int 2000)}}
+    :service-prefix "/service/register"))

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -141,10 +141,10 @@
 (def access-token (atom nil))
 
 
-(defn ajax-orch [path arg-map]
+(defn ajax-orch [path arg-map & {:keys [service-prefix] :or {service-prefix "/service/api"}}]
   (assert (= (subs path 0 1) "/") (str "Path must start with '/': " path))
   (ajax (assoc
-         arg-map :url (str "/service/api" path)
+         arg-map :url (str service-prefix path)
          :headers (merge {"Authorization" (str "Bearer " @access-token)}
                          (:headers arg-map)))))
 


### PR DESCRIPTION
This PR goes hand in hand with an Orchestration component: https://github.com/broadinstitute/firecloud-orchestration/pull/153