### PR TITLE
DSDEEPB-1714: download proxy

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
@@ -2,7 +2,7 @@
   (:require
     [dmohs.react :as react]
     [clojure.set :refer [union]]
-    [goog.net.cookies :as cks]
+    goog.net.cookies
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
@@ -11,10 +11,10 @@
     [org.broadinstitute.firecloud-ui.common.table-utils :as table-utils]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
-    [org.broadinstitute.firecloud-ui.utils :as utils :refer [access-token]]
     [org.broadinstitute.firecloud-ui.page.workspace.data.copy-data-workspaces :as copy-data-workspaces]
     [org.broadinstitute.firecloud-ui.page.workspace.data.entity-selector :refer [EntitySelector]]
     [org.broadinstitute.firecloud-ui.page.workspace.data.import-data :as import-data]
+    [org.broadinstitute.firecloud-ui.utils :as utils :refer [access-token]]
     ))
 
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
@@ -61,7 +61,7 @@
                 (when-let [selected-entity-type (or (:selected-entity-type @state) (:initial-entity-type @state) (first (:entity-types @state)))]
                   [:a {:style {:textDecoration "none" :float "left" :margin "7px 0 0 1em"}
                        :href (str "/service/api/workspaces/" (:namespace (:workspace-id props)) "/"
-                               (:name (:workspace-id props)) "/" selected-entity-type "/tsv")
+                               (:name (:workspace-id props)) "/entities/" selected-entity-type "/tsv")
                        :target "_blank"}
                    (str "Download '" selected-entity-type "' data")])
                 [:div {:style {:float "right" :paddingRight "2em"}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
@@ -2,6 +2,7 @@
   (:require
     [dmohs.react :as react]
     [clojure.set :refer [union]]
+    [goog.net.cookies :as cks]
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
@@ -10,6 +11,7 @@
     [org.broadinstitute.firecloud-ui.common.table-utils :as table-utils]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
+    [org.broadinstitute.firecloud-ui.utils :as utils :refer [access-token]]
     [org.broadinstitute.firecloud-ui.page.workspace.data.copy-data-workspaces :as copy-data-workspaces]
     [org.broadinstitute.firecloud-ui.page.workspace.data.entity-selector :refer [EntitySelector]]
     [org.broadinstitute.firecloud-ui.page.workspace.data.import-data :as import-data]
@@ -62,6 +64,7 @@
                   [:a {:style {:textDecoration "none" :float "left" :margin "7px 0 0 1em"}
                        :href (str "/service/api/workspaces/" (:namespace (:workspace-id props)) "/"
                                (:name (:workspace-id props)) "/entities/" selected-entity-type "/tsv")
+                       :onClick (fn [] (.set goog.net.cookies "FCtoken" @access-token 300))
                        :target "_blank"}
                    (str "Download '" selected-entity-type "' data")])
                 [:div {:style {:float "right" :paddingRight "2em"}}

--- a/src/docker/run-apache.sh
+++ b/src/docker/run-apache.sh
@@ -45,6 +45,15 @@ EOF
 )
 
 LOCATION_DIRECTIVES=$(cat << EOF
+  <LocationMatch "/service/api/workspaces/[^/]+/[^/]+/entities/[^/]+/tsv">
+    RewriteEngine On
+    RewriteCond %{HTTP_COOKIE} FCtoken=([^;]+)
+    RewriteRule .* - [END,QSD,env=ACCESSTOKEN:%1]
+    RequestHeader set Authorization "Bearer %{ACCESSTOKEN}e"
+    ProxyPass ${ORCH_URL_ROOT}
+    ProxyPassReverse ${ORCH_URL_ROOT}
+  </LocationMatch>
+
   <Location "/service">
     ProxyPass ${ORCH_URL_ROOT}
     ProxyPassReverse ${ORCH_URL_ROOT}


### PR DESCRIPTION
one-line fix to point the UI at the right endpoint for downloading TSVs.

new Location directive, containing a rewrite rule, for the proxy itself. This directive looks for a cookie named "FCtoken", and copies the value of that cookie into an Authorization: Bearer header.