### PR TITLE
DSDEEPB-2053: Profile registration now makes single call to orchestration

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -559,11 +559,12 @@
      :service-prefix "/service/register")))
 
 
-(defn profile-set [k v on-done]
+(defn profile-set [payload on-done]
   (utils/ajax-orch
-    (str "/profile/" (name k))
+    "/profile"
     {:method :post
-    :data v
+    :data (utils/->json-string payload)
     :on-done on-done
+    :headers {"Content-Type" "application/json"}
     :canned-response {:status (rand-nth [200 200 500]) :delay-ms (rand-int 2000)}}
     :service-prefix "/service/register"))


### PR DESCRIPTION
See me on how to test this, as it involves manually deleting your existing registration keys, and that info is not something I want to put into a public repository.

The change here is to make a single call to orchestration's profile service, instead of one call per profile key.

I'll clean up the orchestration side of things in a follow-on story, when I tackle DSDEEPB-2046.