### PR TITLE
Remove unnecessary encoding

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
@@ -175,8 +175,6 @@
        [comps/Button
         {:text "Sign In"
          :href (str "/service/login?callback="
-                    (js/encodeURIComponent
-                     (str js/window.location.protocol "//" js/window.location.hostname))
                     (let [hash (nav/get-hash-value)]
                       (if (clojure.string/blank? hash) "" (str "&path=" hash))))}]]
       [:div {:style {:marginTop "1em"}} [RegisterLink]]


### PR DESCRIPTION
The encoded protocol + location breaks local https development. Without that, both http and https sign-ins work as expected.