### PR TITLE
DSDEEPB-2101: break out ErrorViewer, CauseViewer, StackTraceViewer into separate components

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -214,7 +214,7 @@
                       (str "at " class "." method " (" file ":" num ")")]))
             (:lines props))
           (style/create-link #(swap! state assoc :expanded? false) "Hide Stack Trace")]
-         (style/create-link #(swap! state assoc :expanded? true) "Show Stack Trace")))})
+         [:div {} (style/create-link #(swap! state assoc :expanded? true) "Show Stack Trace")]))})
 
 (react/defc CauseViewer
   {:render

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -200,63 +200,62 @@
         [:div {:style {:fontSize "90%"}} (entity "documentation")])])})
 
 
-(declare CauseViewer)
+(react/defc StackTraceViewer
+  {:render
+   (fn [{:keys [props state]}]
+       (if (:expanded? @state)
+         [:div {:style {:overflowX "auto"}}
+          [:div {} "Stack Trace:"]
+          (map
+            (fn [line]
+                (let [[class method file num]
+                      (map line ["className" "methodName" "fileName" "lineNumber"])]
+                     [:div {:style {:marginLeft "1em" :whiteSpace "nowrap"}}
+                      (str "at " class "." method " (" file ":" num ")")]))
+            (:lines props))
+          (style/create-link #(swap! state assoc :expanded? false) "Hide Stack Trace")]
+         (style/create-link #(swap! state assoc :expanded? true) "Show Stack Trace")))})
+
+(react/defc CauseViewer
+  {:render
+   (fn [{:keys [props state]}]
+       (if (:expanded? @state)
+         (let [[source causes stack-trace message]
+               (map props ["source" "causes" "stackTrace" "message"])]
+              [:div {:style {:marginLeft "1em"}}
+               [:div {} "Message: " message]
+               (when source [:div {} "Source: " source])
+               (when (seq causes)
+                     [:div {}
+                      [:div {} (str "Cause" (when (> (count causes) 1) "s") ":")]
+                      (map (fn [cause] [CauseViewer cause]) causes)])
+               (when (seq stack-trace)
+                     [StackTraceViewer {:lines stack-trace}])
+               (style/create-link #(swap! state assoc :expanded? false) "Hide Cause")])
+         (style/create-link #(swap! state assoc :expanded? true) "Show Cause")))})
+
 (react/defc ErrorViewer
-  (let [StackTraceViewer
-        (react/create-class
-          {:render
-           (fn [{:keys [props state]}]
-             (if (:expanded? @state)
-               [:div {:style {:overflowX "auto"}}
-                [:div {} "Stack Trace:"]
-                (map
-                  (fn [line]
-                    (let [[class method file num]
-                          (map line ["className" "methodName" "fileName" "lineNumber"])]
-                      [:div {:style {:marginLeft "1em" :whiteSpace "nowrap"}}
-                       (str "at " class "." method " (" file ":" num ")")]))
-                  (:lines props))
-                (style/create-link #(swap! state assoc :expanded? false) "Hide Stack Trace")]
-               (style/create-link #(swap! state assoc :expanded? true) "Show Stack Trace")))})
-        CauseViewer
-        (react/create-class
-          {:render
-           (fn [{:keys [props state]}]
-             (if (:expanded? @state)
-               (let [[source causes stack-trace message]
-                     (map props ["source" "causes" "stackTrace" "message"])]
-                 [:div {:style {:marginLeft "1em"}}
-                  [:div {} "Message: " message]
-                  (when source [:div {} "Source: " source])
-                  (when-not (empty? causes)
-                    [:div {}
-                     [:div {} (str "Cause" (when (> (count causes) 1) "s") ":")]
-                     (map (fn [cause] [CauseViewer cause]) causes)])
-                  (when-not (empty? stack-trace)
-                    [StackTraceViewer {:lines stack-trace}])
-                  (style/create-link #(swap! state assoc :expanded? false) "Hide Cause")])
-               (style/create-link #(swap! state assoc :expanded? true) "Show Cause")))})]
-    {:render
-     (fn [{:keys [props]}]
-       (when-let [error (:error props)]
-         (let [[source status-code causes stack-trace message]
-               (map error ["source" "statusCode" "causes" "stackTrace" "message"])]
-           (if-let [expected-msg (get-in props [:expect status-code])]
-             [:div {}
-              [:span {:style {:paddingRight "1ex"}}
-               (icons/font-icon {:style {:color (:exception-red style/colors)}}
-                 :status-warning-triangle)]
-              (str "Error: " expected-msg)]
-             [:div {:style {:textAlign "initial"}}
+  {:render
+   (fn [{:keys [props]}]
+     (when-let [error (:error props)]
+       (let [[source status-code causes stack-trace message]
+             (map error ["source" "statusCode" "causes" "stackTrace" "message"])]
+         (if-let [expected-msg (get-in props [:expect status-code])]
+           [:div {}
+            [:span {:style {:paddingRight "1ex"}}
+             (icons/font-icon {:style {:color (:exception-red style/colors)}}
+               :status-warning-triangle)]
+            (str "Error: " expected-msg)]
+           [:div {:style {:textAlign "initial"}}
+            [:div {}
+             [:span {:style {:paddingRight "1ex"}}
+              (icons/font-icon {:style {:color (:exception-red style/colors)}}
+                :status-warning-triangle)]
+             (str "Error " status-code ": " message)]
+            (when source [:div {} "Source: " source])
+            (when (seq causes)
               [:div {}
-               [:span {:style {:paddingRight "1ex"}}
-                (icons/font-icon {:style {:color (:exception-red style/colors)}}
-                  :status-warning-triangle)]
-               (str "Error " status-code ": " message)]
-              (when source [:div {} "Source: " source])
-              (when-not (empty? causes)
-                [:div {}
-                 [:div {} (str "Cause" (when (> (count causes) 1) "s") ":")]
-                 (map (fn [cause] [CauseViewer cause]) causes)])
-              (when-not (empty? stack-trace)
-                [StackTraceViewer {:lines stack-trace}])]))))}))
+               [:div {} (str "Cause" (when (> (count causes) 1) "s") ":")]
+               (map (fn [cause] [CauseViewer cause]) causes)])
+            (when (seq stack-trace)
+              [StackTraceViewer {:lines stack-trace}])]))))})


### PR DESCRIPTION
to avoid the JS error mentioned in the bug.

Note: there are still other problems with the ErrorViewer:
1) The "Show Stack Trace" and "Hide Cause" links run up against each other visually, in an ugly way
2) There is a similar but not identical JS problem I found during copying data which prevents the modal from being closed.

I will file separate tickets for both of these - I'd rather get this refactoring in "clean" without those changes.

update: DSDEEPB-2187 tracks item 2 above. I decided to just fix item 1 as part of this PR because it's so small; I've done that as a separate commit to keep the code changes cleaner.