### PR TITLE
DSDEEPB-1534: Initial work on workspace navigation

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -126,3 +126,8 @@
 (defn parse-profile [unparsed-profile]
   (let [unparsed-values (get unparsed-profile "keyValuePairs")]
     (into {} (map (fn [m] [(keyword (m "key")) (m "value")]) unparsed-values))))
+
+(defn get-id-from-nav-segment [segment]
+  (when-not (clojure.string/blank? segment)
+    (let [[ns n] (clojure.string/split segment #":")]
+      {:namespace ns :name n})))

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -268,14 +268,12 @@
 
 
 (defn- validate-crumb [crumb]
-  (and (contains? crumb :text)
-       (or (contains? crumb :on-click)
-           (contains? crumb :href))))
+  (contains? crumb :text))
 
 (react/defc Breadcrumbs
   {:push
    (fn [{:keys [state]} new-crumb]
-     (assert (validate-crumb new-crumb) "Crumb must have :text and :on-click or :href")
+     (assert (validate-crumb new-crumb) "Crumb must have :text")
      (swap! state update-in [:crumbs] conj new-crumb))
    :set-crumbs
    (fn [{:keys [state]} crumbs]
@@ -284,7 +282,7 @@
    :get-initial-state
    (fn [{:keys [props]}]
      (assert (every? validate-crumb (:initial-crumbs props))
-       "Each initial crumb must have :text and :on-click or :href")
+       "Each initial crumb must have :text")
      {:crumbs (vec (:initial-crumbs props))})
    :render
    (fn [{:keys [state]}]
@@ -297,9 +295,11 @@
           (interpose sep
             (map-indexed
               (fn [index {:keys [text on-click href]}]
-                (style/create-link2 {:href href :text text
-                                     :onClick #(do (when on-click (on-click))
-                                                   (swap! state update-in [:crumbs] subvec 0 (inc index)))}))
+                (if (or on-click href)
+                  (style/create-link2 {:href href :text text
+                                       :onClick #(do (when on-click (on-click))
+                                                   (swap! state update-in [:crumbs] subvec 0 (inc index)))})
+                  text))
               (butlast crumbs)))
           sep
           (:text (last crumbs))])))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -76,8 +76,8 @@
        (set! (.-renderArgs this) render-args)
        (swap! state assoc :active-tab-index index))
      :get-initial-state
-     (fn []
-       {:active-tab-index 0})
+     (fn [{:keys [props]}]
+       {:active-tab-index (or (:initial-tab-index props) 0)})
      :render
      (fn [{:keys [this props state]}]
        [:div {}
@@ -96,7 +96,13 @@
          (common/clear-both)]
         (let [active-item (nth (:items props) (:active-tab-index @state))
               render (:render active-item)]
-          [:div {} (apply render (.-renderArgs this))])])}))
+          [:div {} (apply render (.-renderArgs this))])])
+     :component-did-mount
+     (fn [{:keys [props]}]
+       (let [index (or (:initial-tab-index props) 0)
+             onTabSelected (get-in props [:items index :onTabSelected])]
+         (when onTabSelected
+           (onTabSelected))))}))
 
 
 (react/defc XButton
@@ -259,3 +265,41 @@
                (map (fn [cause] [CauseViewer cause]) causes)])
             (when (seq stack-trace)
               [StackTraceViewer {:lines stack-trace}])]))))})
+
+
+(defn- validate-crumb [crumb]
+  (and (contains? crumb :text)
+       (or (contains? crumb :on-click)
+           (contains? crumb :href))))
+
+(react/defc Breadcrumbs
+  {:push
+   (fn [{:keys [state]} new-crumb]
+     (assert (validate-crumb new-crumb) "Crumb must have :text and :on-click or :href")
+     (swap! state update-in [:crumbs] conj new-crumb))
+   :set-crumbs
+   (fn [{:keys [state]} crumbs]
+     (assert (every? validate-crumb crumbs))
+     (swap! state assoc :crumbs (vec crumbs)))
+   :get-initial-state
+   (fn [{:keys [props]}]
+     (assert (every? validate-crumb (:initial-crumbs props))
+       "Each initial crumb must have :text and :on-click or :href")
+     {:crumbs (vec (:initial-crumbs props))})
+   :render
+   (fn [{:keys [state]}]
+     (let [sep (icons/font-icon {:style {:fontSize "50%" :margin "0 0.5em"}} :angle-right)
+           crumbs (:crumbs @state)]
+       (case (count crumbs)
+         0 [:div {}]
+         1 [:div {} (:text (first crumbs))]
+         [:div {}
+          (interpose sep
+            (map-indexed
+              (fn [index {:keys [text on-click href]}]
+                (style/create-link2 {:href href :text text
+                                     :onClick #(do (when on-click (on-click))
+                                                   (swap! state update-in [:crumbs] subvec 0 (inc index)))}))
+              (butlast crumbs)))
+          sep
+          (:text (last crumbs))])))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
@@ -86,6 +86,13 @@
                              :KhtmlUserSelect "none" :MsUserSelect "none"}} props)
    children])
 
+(defn create-link2 [{:keys [href style onClick text]}]
+  [:a (merge
+        {:href (or href "javascript:;")
+         :style (merge {:textDecoration "none" :color (:button-blue colors)} style)}
+        (when onClick {:onClick onClick}))
+   text])
+
 (defn create-link [onClick & children]
   [:a {:href "javascript:;"
        :style {:textDecoration "none" :color (:button-blue colors)}

--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -175,19 +175,19 @@
            "/method_configs/" (config "namespace") "/" (config "name"))
    :method :delete})
 
-(defn get-validated-workspace-method-config [workspace-id config]
+(defn get-validated-workspace-method-config [workspace-id config-id]
   {:path (str "/workspaces/" (ws-path workspace-id)
-           "/method_configs/" (config "namespace") "/" (config "name") "/validate")
+           "/method_configs/" (:namespace config-id) "/" (:name config-id) "/validate")
    :method :get
    :mock-data
-   {:methodConfiguration {:name (str (config "name"))
+   {:methodConfiguration {:name (:name config-id)
                           :namespace (rand-nth ["Broad" "nci" "public"])
                           :rootEntityType (rand-nth ["sample" "participant"])
-                          :methodRepoMethod {:methodNamespace (str (config "namespace"))
-                                             :methodName (str (config "name"))
+                          :methodRepoMethod {:methodNamespace (:namespace config-id)
+                                             :methodName (:name config-id)
                                              :methodVersion (str "ms_v_1")}
-                          :methodStoreConfig {:methodConfigNamespace (str (config "namespace"))
-                                              :methodConfigName (str (config "name"))
+                          :methodStoreConfig {:methodConfigNamespace (:namespace config-id)
+                                              :methodConfigName (:name config-id)
                                               :methodConfigVersion (str "msc_v_1")}
                           ;; Real data doesn't have the following fields, but for mock data we carry the same
                           ;; objects around, so initialize them here for convenience

--- a/src/cljs/org/broadinstitute/firecloud_ui/nav.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/nav.cljs
@@ -35,3 +35,7 @@
 (defn navigate [nav-context segment-name]
   (set! (-> js/window .-location .-hash)
         (str (apply str (reverse (:consumed nav-context))) (js/encodeURIComponent segment-name))))
+
+(defn back [nav-context]
+  (set! (-> js/window .-location .-hash)
+    (str (apply str (butlast (reverse (:consumed nav-context)))))))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -1,7 +1,9 @@
 (ns org.broadinstitute.firecloud-ui.page.workspace.details
   (:require
     [dmohs.react :as react]
+    [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.nav :as nav]
     [org.broadinstitute.firecloud-ui.page.workspace.data.tab :as data-tab]
     [org.broadinstitute.firecloud-ui.page.workspace.method-configs.tab :as method-configs-tab]
     [org.broadinstitute.firecloud-ui.page.workspace.monitor.tab :as monitor-tab]
@@ -9,23 +11,51 @@
     ))
 
 
+(def ^:private SUMMARY "Summary")
+(def ^:private DATA "Data")
+(def ^:private CONFIGS "Method Configurations")
+(def ^:private MONITOR "Monitor")
+(defn- tab-string-to-index [tab-string]
+  ;; for some reason the more compact "case" isn't working with strings :(
+  (cond
+    (= tab-string SUMMARY) 0
+    (= tab-string DATA) 1
+    (= tab-string CONFIGS) 2
+    (= tab-string MONITOR) 3
+    :else 0))
+
 (react/defc WorkspaceDetails
   {:render
    (fn [{:keys [props refs]}]
-     [:div {:style {:margin "0 -1em"}}
-      [comps/TabBar {:ref "tab-bar"
-                     :items
-                     [{:text "Summary"
-                       :render #(summary-tab/render (:workspace-id props)
-                                 (:on-delete props)
-                                 (:nav-context props))}
-                      {:text "Data" :render #(data-tab/render (:workspace-id props))}
-                      {:text "Method Configurations"
-                       :render (fn []
-                                 (method-configs-tab/render
-                                  (:workspace-id props)
-                                  #(react/call :set-active-tab (@refs "tab-bar") 3 %)))}
-                      {:text "Monitor" :render #(monitor-tab/render (:workspace-id props) %)}]}]])})
+     (let [nav-context (nav/parse-segment (:nav-context props))
+           workspace-id (common/get-id-from-nav-segment (:segment nav-context))
+           tab-context (nav/parse-segment nav-context)
+           tab (:segment tab-context)]
+       [:div {:style {:margin "0 -1em"}}
+        [comps/TabBar {:ref "tab-bar"
+                       :initial-tab-index (tab-string-to-index tab)
+                       :items
+                       [{:text SUMMARY
+                         :render #(summary-tab/render
+                                    workspace-id
+                                    (:on-delete props)
+                                    nav-context)
+                         :onTabSelected #(nav/navigate nav-context SUMMARY)}
+                        {:text DATA
+                         :render #(data-tab/render (:workspace-id props))
+                         :onTabSelected #(nav/navigate nav-context DATA)}
+                        {:text CONFIGS
+                         :render (fn []
+                                   (method-configs-tab/render
+                                     workspace-id
+                                     #(react/call :set-active-tab (@refs "tab-bar") 3 %)
+                                     tab-context))
+                         :onTabSelected #(when (empty? (:remaining tab-context))
+                                           (nav/navigate nav-context CONFIGS))}
+                        {:text MONITOR
+                         :render (fn [submission-id]
+                                   (monitor-tab/render workspace-id submission-id))
+                         :onTabSelected #(nav/navigate nav-context MONITOR)}]}]]))})
 
 
 (defn render-workspace-details [workspace-id on-delete nav-context]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -28,9 +28,8 @@
   {:render
    (fn [{:keys [props refs]}]
      (let [nav-context (nav/parse-segment (:nav-context props))
-           workspace-id (common/get-id-from-nav-segment (:segment nav-context))
-           tab-context (nav/parse-segment nav-context)
-           tab (:segment tab-context)]
+           workspace-id (:workspace-id props)
+           tab (:segment nav-context)]
        [:div {:style {:margin "0 -1em"}}
         [comps/TabBar {:ref "tab-bar"
                        :initial-tab-index (tab-string-to-index tab)
@@ -40,22 +39,22 @@
                                     workspace-id
                                     (:on-delete props)
                                     nav-context)
-                         :onTabSelected #(nav/navigate nav-context SUMMARY)}
+                         :onTabSelected #(nav/navigate (:nav-context props) SUMMARY)}
                         {:text DATA
                          :render #(data-tab/render (:workspace-id props))
-                         :onTabSelected #(nav/navigate nav-context DATA)}
+                         :onTabSelected #(nav/navigate (:nav-context props) DATA)}
                         {:text CONFIGS
                          :render (fn []
                                    (method-configs-tab/render
                                      workspace-id
                                      #(react/call :set-active-tab (@refs "tab-bar") 3 %)
-                                     tab-context))
-                         :onTabSelected #(when (empty? (:remaining tab-context))
-                                           (nav/navigate nav-context CONFIGS))}
+                                     nav-context))
+                         :onTabSelected #(when (empty? (:remaining nav-context))
+                                           (nav/navigate (:nav-context props) CONFIGS))}
                         {:text MONITOR
                          :render (fn [submission-id]
                                    (monitor-tab/render workspace-id submission-id))
-                         :onTabSelected #(nav/navigate nav-context MONITOR)}]}]]))})
+                         :onTabSelected #(nav/navigate (:nav-context props) MONITOR)}]}]]))})
 
 
 (defn render-workspace-details [workspace-id on-delete nav-context]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
@@ -215,7 +215,7 @@
    :component-did-mount
    (fn [{:keys [state props refs this]}]
      (endpoints/call-ajax-orch
-       {:endpoint (endpoints/get-validated-workspace-method-config (:workspace-id props) (:config props))
+       {:endpoint (endpoints/get-validated-workspace-method-config (:workspace-id props) (:config-id props))
         :on-done (fn [{:keys [success? get-parsed-response status-text]}]
                    (if success?
                      (swap! state assoc :loaded-config (get-parsed-response))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
@@ -41,7 +41,7 @@
                       [MethodConfigImporter {:workspace-id (:workspace-id props)
                                              :after-import (fn [config]
                                                              (swap! state dissoc :show-import-overlay?)
-                                                             ((:on-config-imported props) config))}]])}])
+                                                             ((:on-config-imported props) (config->id config)))}]])}])
       (let [server-response (:server-response @state)
             {:keys [configs error-message]} server-response]
         (cond

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -212,10 +212,11 @@
   (let [segments (split hash #"/")]
     (map-indexed
       (fn [index segment]
-        {:text (if (zero? index)
-                 "Workspaces"
-                 (replace (js/decodeURIComponent segment) ":" "/"))
-         :href (str "#" (join "/" (subvec segments 0 (inc index))))})
+        (case index
+          0 {:text "Workspaces" :href "#workspaces"}
+          1 {:text (replace (js/decodeURIComponent segment) ":" "/")}
+          {:text (replace (js/decodeURIComponent segment) ":" "/")
+           :href (str "#" (join "/" (subvec segments 0 (inc index))))}))
       segments)))
 
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -1,6 +1,6 @@
 (ns org.broadinstitute.firecloud-ui.page.workspaces-list
   (:require
-    clojure.string
+    [clojure.string :refer [split join replace]]
     [dmohs.react :as react]
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
@@ -208,30 +208,40 @@
                        assoc :error-message status-text)))}))})
 
 
-(defn- get-workspace-id-from-nav-segment [segment]
-  (when-not (clojure.string/blank? segment)
-    (let [[ns n] (clojure.string/split segment #":")]
-      {:namespace ns :name n})))
+(defn- create-breadcrumbs-from-hash [hash]
+  (let [segments (split hash #"/")]
+    (map-indexed
+      (fn [index segment]
+        {:text (if (zero? index)
+                 "Workspaces"
+                 (replace (js/decodeURIComponent segment) ":" "/"))
+         :href (str "#" (join "/" (subvec segments 0 (inc index))))})
+      segments)))
 
 
 (react/defc Page
   {:render
-   (fn [{:keys [props state refs]}]
+   (fn [{:keys [props refs]}]
      (let [nav-context (nav/parse-segment (:nav-context props))
-           selected-ws-id (get-workspace-id-from-nav-segment (:segment nav-context))]
+           selected-ws-id (common/get-id-from-nav-segment (:segment nav-context))]
        [:div {}
         [:div {:style {:padding "2em"}}
          [:span {:style {:fontSize "180%"}}
-          (if selected-ws-id
-            (str "Workspace: " (:namespace selected-ws-id) "/" (:name selected-ws-id))
-            "Workspaces")]]
+          [comps/Breadcrumbs {:ref "breadcrumbs"}]]]
         (if selected-ws-id
-          ;; TODO: add 'back' function to nav
-          (render-workspace-details selected-ws-id
-            #(set! (-> js/window .-location .-hash) "workspaces") (:nav-context props))
+          (render-workspace-details selected-ws-id #(nav/back nav-context) (:nav-context props))
           [WorkspaceList
            {:onWorkspaceSelected
             (fn [workspace]
               (nav/navigate nav-context (str (workspace "namespace") ":" (workspace "name")))
               (common/scroll-to-top))
-            :nav-context nav-context}])]))})
+            :nav-context nav-context}])]))
+   :component-did-mount
+   (fn [{:keys [this refs]}]
+     (set! (.-onHashChange this)
+       #(react/call :set-crumbs (@refs "breadcrumbs") (create-breadcrumbs-from-hash (nav/get-hash-value))))
+     ((.-onHashChange this))
+     (.addEventListener js/window "hashchange" (.-onHashChange this)))
+   :component-will-unmount
+   (fn [{:keys [this]}]
+     (.removeEventListener js/window "hashchange" (.-onHashChange this)))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -230,7 +230,7 @@
          [:span {:style {:fontSize "180%"}}
           [comps/Breadcrumbs {:ref "breadcrumbs"}]]]
         (if selected-ws-id
-          (render-workspace-details selected-ws-id #(nav/back nav-context) (:nav-context props))
+          (render-workspace-details selected-ws-id #(nav/back nav-context) nav-context)
           [WorkspaceList
            {:onWorkspaceSelected
             (fn [workspace]


### PR DESCRIPTION
This PR doesn't complete the story, so don't move the JIRA item through the board.  I'd like to get this in as a major checkpoint, and to let people start looking at it.

-----

Made a breadcrumb chain along the top, which threads through to all views except submission details.  This involves using the browser hash instead of state variables to control the view.

Known shortcomings:
* ~~Second link (pointing to workspace namespace:name) is weird--clicking on it will direct the browser to the summary page, but without "/Summary" in the URL or breadcrumbs.  Doesn't break anything but is sort of wonky.~~ **Edit:** second commit fixes this.
* Should also be implemented for submission details
* style/create-link is left in limbo.  The finishing PR will clean this up.