### PR TITLE
Redirect user to home page 

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -88,12 +88,15 @@
           call-on-done (fn []
                          (let [status-code (.-status xhr)
                                get-parsed-response #(parse-json-string (.-responseText xhr))]
-                           (on-done {:xhr xhr
-                                     :status-code status-code
-                                     :success? (and (>= status-code 200)
-                                                    (< status-code 300))
-                                     :status-text (.-statusText xhr)
-                                     :get-parsed-response get-parsed-response})))]
+                           ; TODO: Fix this with a real log-out once the login bug is fixed and logout is implemented.
+                           (if (= status-code 401)
+                             (set! (-> js/window .-location) (str js/window.location.protocol "//" js/window.location.hostname))
+                             (on-done {:xhr xhr
+                                       :status-code status-code
+                                       :success? (and (>= status-code 200)
+                                                      (< status-code 300))
+                                       :status-text (.-statusText xhr)
+                                       :get-parsed-response get-parsed-response}))))]
       (when with-credentials?
         (set! (.-withCredentials xhr) true))
       (if canned-response-params

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -90,7 +90,7 @@
                                get-parsed-response #(parse-json-string (.-responseText xhr))]
                            ; TODO: Fix this with a real log-out once the login bug is fixed and logout is implemented.
                            (if (= status-code 401)
-                             (set! (-> js/window .-location) (str js/window.location.protocol "//" js/window.location.hostname))
+                             (set! (-> js/window .-location) "/")
                              (on-done {:xhr xhr
                                        :status-code status-code
                                        :success? (and (>= status-code 200)


### PR DESCRIPTION
If an unauthorized message comes back from any ajax call. This is a temporary solution and needs further work to make use of the ability to fully logout a user. Also, this does not address the problem of authenticated user with disabled LDAP settings getting an unauthenticated error.