### PR TITLE
Breadcrumbs tweaks

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -96,11 +96,8 @@
                                 (when f (f e))))}])
            (:items props))
          (common/clear-both)]
-        (let [active-item (nth (:items props) (:active-tab-index @state))
-              render (:render active-item)]
-          (if (fn? render)
-            [:div {} (apply render (.-renderArgs this))]
-            [:div {} render]))])
+        (let [active-item (nth (:items props) (:active-tab-index @state))]
+          (:content active-item))])
      :component-did-mount
      (fn [{:keys [props]}]
        (let [index (or (:initial-tab-index props) 0)
@@ -281,7 +278,7 @@
      (swap! state update-in [:crumbs] conj new-crumb))
    :set-crumbs
    (fn [{:keys [state]} crumbs]
-     (assert (every? validate-crumb crumbs))
+     (assert (every? validate-crumb crumbs) "Every crumb must have :text")
      (swap! state assoc :crumbs (vec crumbs)))
    :get-initial-state
    (fn [{:keys [props]}]

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -73,23 +73,25 @@
                                    :backgroundColor "white"}}])])})]
     {:render
      (fn [{:keys [this props]}]
-       [:div {}
-        [:div {:style {:backgroundColor (:background-gray style/colors)
-                       :borderTop (str "1px solid " (:line-gray style/colors))
-                       :borderBottom (str "1px solid " (:line-gray style/colors))
-                       :padding "0 1.5em"}}
-         (map-indexed
-           (fn [i tab]
-             [Tab {:index i :text (:text tab)
-                   :active? (= i (:selected-index props))
-                   :onClick (fn [e]
-                              (let [k (if (= i (:selected-index props)) :onTabRefreshed :onTabSelected)
-                                    f (tab k)]
-                                (when f (f e))))}])
-           (:items props))
-         (common/clear-both)]
-        (let [active-item (nth (:items props) (:selected-index props))]
-          (:content active-item))])}))
+       (let [{:keys [selected-index items]} props]
+         [:div {}
+          [:div {:key selected-index
+                 :style {:backgroundColor (:background-gray style/colors)
+                         :borderTop (str "1px solid " (:line-gray style/colors))
+                         :borderBottom (str "1px solid " (:line-gray style/colors))
+                         :padding "0 1.5em"}}
+           (map-indexed
+             (fn [i tab]
+               [Tab {:index i :text (:text tab)
+                     :active? (= i selected-index)
+                     :onClick (fn [e]
+                                (let [k (if (= i selected-index) :onTabRefreshed :onTabSelected)
+                                      f (tab k)]
+                                  (when f (f e))))}])
+             items)
+           (common/clear-both)]
+          (let [active-item (nth items selected-index)]
+            (:content active-item))]))}))
 
 
 (react/defc XButton

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -178,9 +178,8 @@
         (react/call :render-details this make-field entity)
         [:div {:style {:paddingTop "0.5em"}}
          [:span {:style {:fontWeight 500 :marginRight "1em"}} (if config? "Referenced Method:" "Payload:")]
-         (style/create-link
-           #(swap! state assoc :payload-expanded (not (:payload-expanded @state)))
-           (if (:payload-expanded @state) "Collapse" "Expand"))]
+         (style/create-link {:text (if (:payload-expanded @state) "Collapse" "Expand")
+                             :onClick #(swap! state assoc :payload-expanded (not (:payload-expanded @state)))})]
         (when (:payload-expanded @state)
           (if config?
             [:div {:style {:margin "0.5em 0 0 1em"}}
@@ -220,8 +219,8 @@
                      [:div {:style {:marginLeft "1em" :whiteSpace "nowrap"}}
                       (str "at " class "." method " (" file ":" num ")")]))
             (:lines props))
-          (style/create-link #(swap! state assoc :expanded? false) "Hide Stack Trace")]
-         [:div {} (style/create-link #(swap! state assoc :expanded? true) "Show Stack Trace")]))})
+          (style/create-link {:text "Hide Stack Trace" :onClick #(swap! state assoc :expanded? false)})]
+         [:div {} (style/create-link {:text "Show Stack Trace" :onClick #(swap! state assoc :expanded? true)})]))})
 
 (react/defc CauseViewer
   {:render
@@ -238,8 +237,8 @@
                       (map (fn [cause] [CauseViewer cause]) causes)])
                (when (seq stack-trace)
                      [StackTraceViewer {:lines stack-trace}])
-               (style/create-link #(swap! state assoc :expanded? false) "Hide Cause")])
-         (style/create-link #(swap! state assoc :expanded? true) "Show Cause")))})
+               (style/create-link {:text "Hide Cause" :onClick #(swap! state assoc :expanded? false)})])
+         (style/create-link {:text "Show Cause" :onClick #(swap! state assoc :expanded? true)})))})
 
 (react/defc ErrorViewer
   {:render
@@ -297,9 +296,9 @@
             (map-indexed
               (fn [index {:keys [text on-click href]}]
                 (if (or on-click href)
-                  (style/create-link2 {:href href :text text
-                                       :onClick #(do (when on-click (on-click))
-                                                   (swap! state update-in [:crumbs] subvec 0 (inc index)))})
+                  (style/create-link {:href href :text text
+                                      :onClick #(do (when on-click (on-click))
+                                                    (swap! state update-in [:crumbs] subvec 0 (inc index)))})
                   text))
               (butlast crumbs)))
           sep

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -75,8 +75,7 @@
      (fn [{:keys [this props]}]
        (let [{:keys [selected-index items]} props]
          [:div {}
-          [:div {:key selected-index
-                 :style {:backgroundColor (:background-gray style/colors)
+          [:div {:style {:backgroundColor (:background-gray style/colors)
                          :borderTop (str "1px solid " (:line-gray style/colors))
                          :borderBottom (str "1px solid " (:line-gray style/colors))
                          :padding "0 1.5em"}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -71,15 +71,8 @@
                   (when (:active? props)
                     [:div {:style {:position "absolute" :bottom -1 :left 0 :width "100%" :height 2
                                    :backgroundColor "white"}}])])})]
-    {:set-active-tab
-     (fn [{:keys [this state]} index & render-args]
-       (set! (.-renderArgs this) render-args)
-       (swap! state assoc :active-tab-index index))
-     :get-initial-state
-     (fn [{:keys [props]}]
-       {:active-tab-index (or (:initial-tab-index props) 0)})
-     :render
-     (fn [{:keys [this props state]}]
+    {:render
+     (fn [{:keys [this props]}]
        [:div {}
         [:div {:style {:backgroundColor (:background-gray style/colors)
                        :borderTop (str "1px solid " (:line-gray style/colors))
@@ -88,22 +81,15 @@
          (map-indexed
            (fn [i tab]
              [Tab {:index i :text (:text tab)
-                   :active? (= i (:active-tab-index @state))
+                   :active? (= i (:selected-index props))
                    :onClick (fn [e]
-                              (let [k (if (= i (:active-tab-index @state)) :onTabRefreshed :onTabSelected)
+                              (let [k (if (= i (:selected-index props)) :onTabRefreshed :onTabSelected)
                                     f (tab k)]
-                                (swap! state assoc :active-tab-index i)
                                 (when f (f e))))}])
            (:items props))
          (common/clear-both)]
-        (let [active-item (nth (:items props) (:active-tab-index @state))]
-          (:content active-item))])
-     :component-did-mount
-     (fn [{:keys [props]}]
-       (let [index (or (:initial-tab-index props) 0)
-             onTabSelected (get-in props [:items index :onTabSelected])]
-         (when onTabSelected
-           (onTabSelected))))}))
+        (let [active-item (nth (:items props) (:selected-index props))]
+          (:content active-item))])}))
 
 
 (react/defc XButton

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -267,39 +267,23 @@
               [StackTraceViewer {:lines stack-trace}])]))))})
 
 
-(defn- validate-crumb [crumb]
-  (contains? crumb :text))
-
 (react/defc Breadcrumbs
-  {:push
-   (fn [{:keys [state]} new-crumb]
-     (assert (validate-crumb new-crumb) "Crumb must have :text")
-     (swap! state update-in [:crumbs] conj new-crumb))
-   :set-crumbs
-   (fn [{:keys [state]} crumbs]
-     (assert (every? validate-crumb crumbs) "Every crumb must have :text")
-     (swap! state assoc :crumbs (vec crumbs)))
-   :get-initial-state
+  {:render
    (fn [{:keys [props]}]
-     (assert (every? validate-crumb (:initial-crumbs props))
-       "Each initial crumb must have :text")
-     {:crumbs (vec (:initial-crumbs props))})
-   :render
-   (fn [{:keys [state]}]
-     (let [sep (icons/font-icon {:style {:fontSize "50%" :margin "0 0.5em"}} :angle-right)
-           crumbs (:crumbs @state)]
+     (let [sep [:span {} " " (icons/font-icon {:style {:fontSize "50%"}} :angle-right) " "]
+           crumbs (:crumbs props)]
        (case (count crumbs)
          0 [:div {}]
          1 [:div {} (:text (first crumbs))]
          [:div {}
           (interpose sep
             (map-indexed
-              (fn [index {:keys [text on-click href]}]
-                (if (or on-click href)
-                  (style/create-link {:href href :text text
-                                      :onClick #(do (when on-click (on-click))
-                                                    (swap! state update-in [:crumbs] subvec 0 (inc index)))})
-                  text))
+              (fn [index {:keys [text onClick href] :as link-props}]
+                [:span {:style {:fontSize "60%" :verticalAlign "middle" :whiteSpace "pre"}}
+                 (if (or onClick href)
+                   (style/create-link link-props)
+                   text)])
               (butlast crumbs)))
           sep
-          (:text (last crumbs))])))})
+          [:span {:style {:verticalAlign "middle"}}
+           (:text (last crumbs))]])))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -90,13 +90,17 @@
              [Tab {:index i :text (:text tab)
                    :active? (= i (:active-tab-index @state))
                    :onClick (fn [e]
-                              (swap! state assoc :active-tab-index i)
-                              (when-let [f (:onTabSelected tab)] (f e)))}])
+                              (let [k (if (= i (:active-tab-index @state)) :onTabRefreshed :onTabSelected)
+                                    f (tab k)]
+                                (swap! state assoc :active-tab-index i)
+                                (when f (f e))))}])
            (:items props))
          (common/clear-both)]
         (let [active-item (nth (:items props) (:active-tab-index @state))
               render (:render active-item)]
-          [:div {} (apply render (.-renderArgs this))])])
+          (if (fn? render)
+            [:div {} (apply render (.-renderArgs this))]
+            [:div {} render]))])
      :component-did-mount
      (fn [{:keys [props]}]
        (let [index (or (:initial-tab-index props) 0)

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/dialog.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/dialog.cljs
@@ -134,12 +134,10 @@
                                    (labeled "Created" (common/format-date (data "timeCreated")))
                                    (labeled "Updated" (common/format-date (data "updated")))
                                    (labeled "MD5" (data "md5Hash"))
-                                   (style/create-link
-                                     #(swap! state dissoc :show-details?)
-                                     "Collapse")]
-                                  (style/create-link
-                                    #(swap! state assoc :show-details? true)
-                                    "More info"))])
+                                   (style/create-link {:text "Collapse"
+                                                       :onClick #(swap! state dissoc :show-details?)})]
+                                  (style/create-link {:text "More info"
+                                                      :onClick #(swap! state assoc :show-details? true)}))])
                              (when error
                                [:div {:style {:marginTop "1em"}}
                                 [:span {:style {:color (:exception-red style/colors)}} "Error! "]
@@ -147,13 +145,11 @@
                                 (if (:show-error-details? @state)
                                   [:div {}
                                    [:pre {} error]
-                                   (style/create-link
-                                     #(swap! state dissoc :show-error-details?)
-                                     "Hide detail")]
+                                   (style/create-link {:text "Hide detail"
+                                                       :onClick #(swap! state dissoc :show-error-details?)})]
                                   [:div {}
-                                   (style/create-link
-                                     #(swap! state assoc :show-error-details? true)
-                                     "Show full error response")])])])
+                                   (style/create-link {:text "Show full error response"
+                                                       :onClick #(swap! state assoc :show-error-details? true)})])])])
                  :dismiss-self #(swap! state dissoc :show-dialog?)
                  :show-cancel? false
                  :ok-button [Button {:text "Done" :onClick #(swap! state dissoc :show-dialog?)}]}])}]]))])

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
@@ -86,18 +86,12 @@
                              :KhtmlUserSelect "none" :MsUserSelect "none"}} props)
    children])
 
-(defn create-link2 [{:keys [href style onClick text]}]
+(defn create-link [{:keys [href style onClick text]}]
   [:a (merge
         {:href (or href "javascript:;")
          :style (merge {:textDecoration "none" :color (:button-blue colors)} style)}
         (when onClick {:onClick onClick}))
    text])
-
-(defn create-link [onClick & children]
-  [:a {:href "javascript:;"
-       :style {:textDecoration "none" :color (:button-blue colors)}
-       :onClick onClick}
-   children])
 
 (defn render-entity [namespace name snapshot-id]
   [:div {}

--- a/src/cljs/org/broadinstitute/firecloud_ui/nav.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/nav.cljs
@@ -38,6 +38,12 @@
           (apply str (reverse (:consumed nav-context)))
           (interpose "/" (map js/encodeURIComponent segment-names)))))
 
+(defn terminate [nav-context]
+  (assoc nav-context :remaining ""))
+
+(defn terminate-when [pred nav-context]
+  (if pred (terminate nav-context) nav-context))
+
 (defn back [nav-context]
   (set! (-> js/window .-location .-hash)
     (str (apply str (butlast (reverse (:consumed nav-context)))))))

--- a/src/cljs/org/broadinstitute/firecloud_ui/nav.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/nav.cljs
@@ -32,9 +32,11 @@
               :remaining (subs remaining (inc stop-index)))))))
 
 
-(defn navigate [nav-context segment-name]
+(defn navigate [nav-context & segment-names]
   (set! (-> js/window .-location .-hash)
-        (str (apply str (reverse (:consumed nav-context))) (js/encodeURIComponent segment-name))))
+        (apply str
+          (apply str (reverse (:consumed nav-context)))
+          (interpose "/" (map js/encodeURIComponent segment-names)))))
 
 (defn back [nav-context]
   (set! (-> js/window .-location .-hash)

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_config_importer.cljs
@@ -231,9 +231,8 @@
                    :sort-initial :asc
                    :content-renderer
                    (fn [item]
-                     (style/create-link
-                      #((:on-item-selected props) item)
-                      (style/render-entity (item "namespace") (item "name") (item "snapshotId"))))}
+                     (style/create-link {:text (style/render-entity (item "namespace") (item "name") (item "snapshotId"))
+                                         :onClick #((:on-item-selected props) item)}))}
                   {:header "Synopsis" :starting-width 160}
                   (table/date-column {:header "Created"})
                   {:header "Referenced Method" :starting-width 250
@@ -279,7 +278,8 @@
      [:div {}
       (if-let [item (:selected-item @state)]
         [:div {}
-         (style/create-link #(swap! state dissoc :selected-item) "Methods")
+         (style/create-link {:text "Methods"
+                             :onClick #(swap! state dissoc :selected-item)})
          (icons/font-icon {:style {:verticalAlign "middle" :margin "0 1ex 0 1ex"}} :angle-right)
          [:h2 {:style {:display "inline-block"}} (item "namespace") "/" (item "name")
           [:span {:style {:marginLeft "1ex" :fontWeight "normal"}} "#" (item "snapshotId")]]]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
@@ -77,11 +77,7 @@
        :else [:div {:style {:textAlign "center"}} [comps/Spinner {:text "Loading entities..."}]]))
    :component-did-mount
    (fn [{:keys [props this]}]
-     ((:push-crumb props) {:text (->> props get-namespace-and-name (interpose "/") (apply str))})
      (react/call :load-entities this))
-   :component-will-unmount
-   (fn [{:keys [props]}]
-     ((:pop-crumb props)))
    :load-entities
    (fn [{:keys [state props]}]
      (let [[namespace name] (get-namespace-and-name props)]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_workspaces.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_workspaces.cljs
@@ -24,9 +24,8 @@
                        :as-text #(get-in % ["workspace" "name"]) :sort-by :text
                        :content-renderer
                        (fn [ws]
-                         (style/create-link
-                           #((:onWorkspaceSelected props) ws)
-                           (get-in ws ["workspace" "name"])))}
+                         (style/create-link {:text (get-in ws ["workspace" "name"])
+                                             :onClick #((:onWorkspaceSelected props) ws)}))}
                       {:header "Created By" :starting-width 200}
                       (table/date-column {})
                       {:header "Access Level" :starting-width 100}]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/entity_selector.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/entity_selector.cljs
@@ -30,9 +30,9 @@
                          :as-text #(get-in % [0 "name"]) :sort-by :text
                          :content-renderer
                          (fn [[entity index]]
-                           (style/create-link
-                             #(swap! state update-in [:selected] (if source? conj disj) index)
-                             (entity "name")))}]
+                           (style/create-link {:text (entity "name")
+                                               :onClick #(swap! state update-in [:selected]
+                                                           (if source? conj disj) index)}))}]
                        (map (fn [k] {:header k :starting-width 100 :show-initial? false
                                      :content-renderer
                                      (fn [attr-value]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/import_data.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/import_data.cljs
@@ -48,12 +48,6 @@
            [:span {:style {:margin "-0.5em 0 0 1em"}} "Success!"]]
           [:div {:style {:paddingTop "1em"}}
            [comps/ErrorViewer {:error (:error result)}]]))])
-   :component-did-mount
-   (fn [{:keys [props]}]
-     ((:push-crumb props) {:text "File"}))
-   :component-will-unmount
-   (fn [{:keys [props]}]
-     ((:pop-crumb props)))
    :do-upload
    (fn [{:keys [props state]}]
      (swap! state assoc :loading? true)

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/import_data.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/import_data.cljs
@@ -13,10 +13,7 @@
 (def ^:private preview-limit 4096)
 
 (react/defc Page
-  {:did-load-data?
-   (fn [{:keys [state]}]
-     (:entities-loaded? @state))
-   :render
+  {:render
    (fn [{:keys [state refs this]}]
      [:div {:style {:textAlign "center"}}
       (when (:loading? @state)
@@ -51,6 +48,12 @@
            [:span {:style {:margin "-0.5em 0 0 1em"}} "Success!"]]
           [:div {:style {:paddingTop "1em"}}
            [comps/ErrorViewer {:error (:error result)}]]))])
+   :component-did-mount
+   (fn [{:keys [props]}]
+     ((:push-crumb props) {:text "File"}))
+   :component-will-unmount
+   (fn [{:keys [props]}]
+     ((:pop-crumb props)))
    :do-upload
    (fn [{:keys [props state]}]
      (swap! state assoc :loading? true)

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
@@ -26,10 +26,10 @@
         [comps/XButton {:dismiss (:dismiss props)}]
         (when choice?
           [:div {:style {:padding "0.5em"}}
-           (style/create-link
-             #(swap! state dissoc :importing-from-file :copying-from-workspace)
-             (icons/font-icon {:style {:fontSize "70%" :marginRight "1em"}} :angle-left)
-             "Back")])
+           (style/create-link {:text [:span {}
+                                      (icons/font-icon {:style {:fontSize "70%" :marginRight "1em"}} :angle-left)
+                                      "Back"]
+                               :onClick #(swap! state dissoc :importing-from-file :copying-from-workspace)})])
         (when (:importing-from-file @state)
           [:div {:style {:padding "1em"}}
            [import-data/Page (select-keys props [:workspace-id :reload-data-tab])]])

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
@@ -71,7 +71,7 @@
                         {:ref "EntitySelector"
                          :left-text "Workspace Entities" :right-text "Will Be Deleted"
                          :entities (:entity-list props)}]
-                       [:div {:style {:text-align "center" :marginTop "1em"}}
+                       [:div {:style {:textAlign "center" :marginTop "1em"}}
                         (style/create-validation-error-message (:validation-errors @state))
                         [comps/ErrorViewer {:error (:server-error @state)}]]])
            :ok-button [comps/Button
@@ -107,31 +107,31 @@
                      (swap! state assoc :server-error (get-parsed-response))))}))})
 
 
-(defn- entity-table [state props]
+(defn- entity-table [state workspace-id locked? entity-list entity-types initial-entity-type]
   [table/EntityTable
-   {:entities (:entity-list @state)
-    :entity-types (:entity-types @state)
-    :initial-entity-type (:initial-entity-type @state)
+   {:entities entity-list
+    :entity-types entity-types
+    :initial-entity-type initial-entity-type
     :toolbar (fn [built-in]
                [:div {}
                 [:div {:style {:float "left"}} built-in]
-                (when-let [selected-entity-type (or (:selected-entity-type @state) (:initial-entity-type @state) (first (:entity-types @state)))]
+                (when-let [selected-entity-type (or (:selected-entity-type @state) initial-entity-type (first entity-types))]
                   [:a {:style {:textDecoration "none" :float "left" :margin "7px 0 0 1em"}
-                       :href (str "/service/api/workspaces/" (:namespace (:workspace-id props)) "/"
-                               (:name (:workspace-id props)) "/entities/" selected-entity-type "/tsv")
+                       :href (str "/service/api/workspaces/" (:namespace workspace-id) "/"
+                               (:name workspace-id) "/entities/" selected-entity-type "/tsv")
                        :onClick (fn [] (utils/set-access-token-cookie @access-token))
                        :target "_blank"}
                    (str "Download '" selected-entity-type "' data")])
                 [:div {:style {:float "right" :paddingRight "2em"}}
                  [comps/Button {:text "Import Data..."
-                                :disabled? (if (:locked? @state) "This workspace is locked")
+                                :disabled? (if locked? "This workspace is locked")
                                 :onClick #(swap! state assoc :show-import? true)}]]
                 [:div {:style {:float "right" :paddingRight "2em"}}
                  [comps/Button {:text "Delete..."
-                                :disabled? (if (:locked? @state) "This workspace is locked")
+                                :disabled? (if locked? "This workspace is locked")
                                 :onClick #(swap! state assoc :show-delete? true)}]]
                 (common/clear-both)])
-    :on-filter-change #(swap! state assoc :selected-entity-type (nth (:entity-types @state) %))
+    :on-filter-change #(swap! state assoc :selected-entity-type (nth entity-types %))
     :attribute-renderer (fn [maybe-uri]
                           (if (string? maybe-uri)
                             (if-let [parsed (common/parse-gcs-uri maybe-uri)]
@@ -142,62 +142,61 @@
 
 
 (react/defc WorkspaceData
-  {:get-initial-state
-   (fn []
-     {:load-counter 0})
+  {:refresh
+   (fn [{:keys [state this]} & [entity-type]]
+     (swap! state dissoc :server-response)
+     (react/call :load this entity-type))
    :render
    (fn [{:keys [props state refs this]}]
-     [:div {:style {:padding "1em"}}
-      (when (:deleting? @state)
-        [comps/Blocker {:banner "Deleting..."}])
-      (when (:show-import? @state)
-        [dialog/Dialog {:dismiss-self #(swap! state dissoc :show-import?)
-                        :width "80%"
-                        :content
-                        (react/create-element
-                          [DataImporter {:dismiss #(swap! state dissoc :show-import?)
-                                         :workspace-id (:workspace-id props)
-                                         :reload-data-tab (fn [entity-type]
-                                                            (swap! state dissoc :entity-list :entity-types)
-                                                            (react/call :load this entity-type))}])}])
-      (when (:show-delete? @state)
-        [DataDeleter {:dismiss-self #(swap! state dissoc :show-delete?)
-                      :entity-list (:entity-list @state)
-                      :workspace-id (:workspace-id props)
-                      :reload #(react/call :load this)}])
-      (cond
-        (and (:entity-list @state) (zero? (:load-counter @state))) (entity-table state props)
-        (:error @state) (style/create-server-error-message (:error @state))
-        :else [:div {:style {:textAlign "center"}} [comps/Spinner {:text "Loading entities..."}]])])
+     (let [workspace-id (:workspace-id props)
+           server-response (:server-response @state)
+           {:keys [server-error locked? entity-list entity-types initial-entity-type]} server-response]
+       [:div {:style {:padding "1em"}}
+        (when (:deleting? @state)
+          [comps/Blocker {:banner "Deleting..."}])
+        (when (:show-import? @state)
+          [dialog/Dialog {:dismiss-self #(swap! state dissoc :show-import?)
+                          :width "80%"
+                          :content
+                          (react/create-element
+                            [DataImporter {:dismiss #(swap! state dissoc :show-import?)
+                                           :workspace-id workspace-id
+                                           :reload-data-tab (fn [entity-type]
+                                                              (swap! state dissoc :entity-list :entity-types)
+                                                              (react/call :refresh this entity-type))}])}])
+        (when (:show-delete? @state)
+          [DataDeleter {:dismiss-self #(swap! state dissoc :show-delete?)
+                        :entity-list (:entity-list @state)
+                        :workspace-id workspace-id
+                        :reload #(react/call :refresh this)}])
+        (cond
+          server-error
+          (style/create-server-error-message server-error)
+          (some nil? [locked? entity-list])
+          [:div {:style {:textAlign "center"}} [comps/Spinner {:text "Loading entities..."}]]
+          :else
+          (entity-table state workspace-id locked? entity-list entity-types initial-entity-type))]))
    :component-did-mount
    (fn [{:keys [this]}]
      (react/call :load this))
-   :component-will-receive-props
-   (fn [{:keys [state this]}]
-     (swap! state dissoc :entity-list)
-     (react/call :load this))
    :load
    (fn [{:keys [state props]} & [entity-type]]
-     (when (zero? (:load-counter @state))
-       (swap! state assoc :load-counter 2)
-       (endpoints/call-ajax-orch
-         {:endpoint (endpoints/get-workspace (:workspace-id props))
-          :on-done (fn [{:keys [success? get-parsed-response status-text]}]
-                     (if success?
-                       (swap! state assoc :locked? (get-in (get-parsed-response) ["workspace" "isLocked"]))
-                       (swap! state assoc :error status-text))
-                     (swap! state update-in [:load-counter] dec))})
-       (endpoints/call-ajax-orch
-         {:endpoint (endpoints/get-entities-by-type (:workspace-id props))
-          :on-done (fn [{:keys [success? get-parsed-response status-text]}]
-                     (if success?
-                       (let [entities (get-parsed-response)]
-                         (swap! state assoc
-                           :entity-list entities
-                           :entity-types (distinct (map #(% "entityType") entities))
-                           :initial-entity-type entity-type))
-                       (swap! state assoc :error status-text))
-                     (swap! state update-in [:load-counter] dec))})))})
-
-(defn render [workspace]
-  [WorkspaceData {:workspace-id workspace}])
+     (endpoints/call-ajax-orch
+       {:endpoint (endpoints/get-workspace (:workspace-id props))
+        :on-done (fn [{:keys [success? get-parsed-response status-text]}]
+                   (if success?
+                     (swap! state update-in [:server-response]
+                       assoc :locked? (get-in (get-parsed-response) ["workspace" "isLocked"]))
+                     (swap! state update-in [:server-response]
+                       assoc :server-error status-text)))})
+     (endpoints/call-ajax-orch
+       {:endpoint (endpoints/get-entities-by-type (:workspace-id props))
+        :on-done (fn [{:keys [success? get-parsed-response status-text]}]
+                   (if success?
+                     (let [entities (get-parsed-response)]
+                       (swap! state update-in [:server-response]
+                         assoc :entity-list entities
+                               :entity-types (distinct (map #(% "entityType") entities))
+                               :initial-entity-type entity-type))
+                     (swap! state update-in [:server-response]
+                       assoc :server-error status-text)))}))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -55,7 +55,7 @@
                            [method-configs-tab/Page {:ref CONFIGS
                                                      :workspace-id workspace-id
                                                      :on-submission-success #(nav/navigate (:nav-context props) MONITOR %)
-                                                     :nav-context nav-context}])
+                                                     :nav-context (nav/terminate-when (not= tab CONFIGS) nav-context)}])
                          :onTabSelected #(when (or (empty? (:remaining nav-context))
                                                    (not= CONFIGS tab))
                                            (nav/navigate (:nav-context props) CONFIGS))
@@ -65,7 +65,7 @@
                          (react/create-element
                            [monitor-tab/Page {:ref MONITOR
                                               :workspace-id workspace-id
-                                              :nav-context nav-context}])
+                                              :nav-context (nav/terminate-when (not= tab MONITOR) nav-context)}])
                          :onTabSelected #(when (or (empty? (:remaining nav-context))
                                                    (not= MONITOR tab))
                                            (nav/navigate (:nav-context props) MONITOR))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -30,8 +30,7 @@
            workspace-id (:workspace-id props)
            tab (:segment nav-context)]
        [:div {:style {:margin "0 -1em"}}
-        [comps/TabBar {:ref "tab-bar" :key tab
-                       :initial-tab-index (tab-string-to-index tab)
+        [comps/TabBar {:initial-tab-index (tab-string-to-index tab)
                        :items
                        [{:text SUMMARY
                          :content

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -18,7 +18,6 @@
 (defn- tab-string-to-index [tab-string]
   ;; for some reason the more compact "case" isn't working with strings :(
   (cond
-    (= tab-string SUMMARY) 0
     (= tab-string DATA) 1
     (= tab-string CONFIGS) 2
     (= tab-string MONITOR) 3
@@ -41,7 +40,7 @@
                                                  :workspace-id workspace-id
                                                  :nav-context nav-context
                                                  :on-delete (:on-delete props)}])
-                         :onTabSelected #(nav/navigate (:nav-context props) SUMMARY)
+                         :onTabSelected #(nav/navigate (:nav-context props))
                          :onTabRefreshed #(react/call :refresh (@refs SUMMARY))}
                         {:text DATA
                          :content

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -8,6 +8,7 @@
     [org.broadinstitute.firecloud-ui.page.workspace.method-configs.tab :as method-configs-tab]
     [org.broadinstitute.firecloud-ui.page.workspace.monitor.tab :as monitor-tab]
     [org.broadinstitute.firecloud-ui.page.workspace.summary.tab :as summary-tab]
+    [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
 
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -30,7 +30,7 @@
            workspace-id (:workspace-id props)
            tab (:segment nav-context)]
        [:div {:style {:margin "0 -1em"}}
-        [comps/TabBar {:initial-tab-index (tab-string-to-index tab)
+        [comps/TabBar {:selected-index (tab-string-to-index tab)
                        :items
                        [{:text SUMMARY
                          :content

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -35,7 +35,7 @@
                        :initial-tab-index (tab-string-to-index tab)
                        :items
                        [{:text SUMMARY
-                         :render
+                         :content
                          (react/create-element
                            [summary-tab/Summary {:key workspace-id :ref SUMMARY
                                                  :workspace-id workspace-id
@@ -44,13 +44,13 @@
                          :onTabSelected #(nav/navigate (:nav-context props) SUMMARY)
                          :onTabRefreshed #(react/call :refresh (@refs SUMMARY))}
                         {:text DATA
-                         :render
+                         :content
                          (react/create-element
                            [data-tab/WorkspaceData {:ref DATA :workspace-id workspace-id}])
                          :onTabSelected #(nav/navigate (:nav-context props) DATA)
                          :onTabRefreshed #(react/call :refresh (@refs DATA))}
                         {:text CONFIGS
-                         :render
+                         :content
                          (react/create-element
                            [method-configs-tab/Page {:ref CONFIGS
                                                      :workspace-id workspace-id
@@ -61,7 +61,7 @@
                                            (nav/navigate (:nav-context props) CONFIGS))
                          :onTabRefreshed #(react/call :refresh (@refs CONFIGS))}
                         {:text MONITOR
-                         :render
+                         :content
                          (react/create-element
                            [monitor-tab/Page {:ref MONITOR
                                               :workspace-id workspace-id

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/launch_analysis.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/launch_analysis.cljs
@@ -38,9 +38,8 @@
                       :else "#fff")})
       :entity-name-renderer (fn [e]
                               (let [entity-id (entity->id e)]
-                                (style/create-link
-                                  #(swap! state assoc :selected-entity entity-id)
-                                  (:name entity-id))))}]]
+                                (style/create-link {:text (:name entity-id)
+                                                    :onClick #(swap! state assoc :selected-entity entity-id)})))}]]
    (style/create-form-label "Define Expression")
    (let [disabled (= (:root-entity-type props) (get-in @state [:selected-entity :type]))]
      (style/create-text-field {:placeholder "leave blank for default"

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
@@ -103,7 +103,14 @@
 
 
 (react/defc Page
-  {:render
+  {:refresh
+   (fn [{:keys [props refs]}]
+     (let [nav-context (nav/parse-segment (:nav-context props))
+           selected-method-config-id (common/get-id-from-nav-segment (:segment nav-context))]
+       (if selected-method-config-id
+         (nav/back nav-context)
+         (react/call :reload (@refs "method-config-list")))))
+   :render
    (fn [{:keys [props]}]
      (let [nav-context (nav/parse-segment (:nav-context props))
            selected-method-config-id (common/get-id-from-nav-segment (:segment nav-context))
@@ -119,17 +126,4 @@
            {:ref "method-config-list"
             :workspace-id (:workspace-id props)
             :on-config-selected nav-to
-            :on-config-imported nav-to}])]))
-   :component-will-receive-props
-   (fn [{:keys [props refs]}]
-     (let [nav-context (nav/parse-segment (:nav-context props))
-           selected-method-config-id (common/get-id-from-nav-segment (:segment nav-context))]
-       (if selected-method-config-id
-         (nav/back nav-context)
-         (react/call :reload (@refs "method-config-list")))))})
-
-
-(defn render [workspace-id on-submission-success nav-context]
-  [Page {:workspace-id workspace-id
-         :on-submission-success on-submission-success
-         :nav-context nav-context}])
+            :on-config-imported nav-to}])]))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
@@ -117,7 +117,8 @@
                     (nav/navigate nav-context (str (:namespace config-id) ":" (:name config-id))))]
        [:div {:style {:padding "1em"}}
         (if selected-method-config-id
-          [MethodConfigEditor {:config-id selected-method-config-id
+          [MethodConfigEditor {:key selected-method-config-id
+                               :config-id selected-method-config-id
                                :workspace-id (:workspace-id props)
                                :on-submission-success (:on-submission-success props)
                                :after-delete #(nav/back nav-context)}]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
@@ -63,9 +63,8 @@
             [{:header "Name" :starting-width 240 :as-text #(% "name") :sort-by :text
               :content-renderer
               (fn [config]
-                (style/create-link
-                  #((:on-config-selected props) (config->id config))
-                  (config "name")))}
+                (style/create-link {:text (config "name")
+                                    :onClick #((:on-config-selected props) (config->id config))}))}
              {:header "Root Entity Type" :starting-width 140}
              {:header "Method" :starting-width 800
               :content-renderer (fn [fields] (apply style/render-entity fields))}]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
@@ -41,9 +41,9 @@
                   (fn [x]
                     (let [e (x "workflowEntity")
                           n (str (e "entityName") " (" (e "entityType") ")")]
-                      (style/create-link
-                        #(swap! state assoc :selected-workflow {:id (x "workflowId") :name n})
-                        n)))}
+                      (style/create-link {:text n
+                                          :onClick #(swap! state assoc :selected-workflow {:id (x "workflowId")
+                                                                                           :name n})})))}
                  {:header "Last Changed" :starting-width 280 :as-text moncommon/render-date}
                  {:header "Status" :starting-width 120
                   :content-renderer (fn [status]
@@ -72,9 +72,8 @@
    (fn [{:keys [state props]}]
      [:div {}
       [:div {}
-       (style/create-link
-        #(swap! state dissoc :selected-workflow)
-        "Workflows")
+       (style/create-link {:text "Workflows"
+                           :onClick #(swap! state dissoc :selected-workflow)})
        (icons/font-icon {:style {:verticalAlign "middle" :margin "0 1ex 0 1ex"}} :angle-right)
        [:b {} (:name (:selected-workflow @state))]]
       [:div {:style {:marginTop "1em"}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
@@ -26,9 +26,8 @@
       :sort-by #(% "submissionDate")
       :sort-initial :desc
       :content-renderer (fn [submission]
-                          (style/create-link
-                            #(on-submission-clicked (submission "submissionId"))
-                            (render-date submission)))}
+                          (style/create-link {:text (render-date submission)
+                                              :onClick #(on-submission-clicked (submission "submissionId"))}))}
      {:header "Status" :as-text #(% "status") :sort-by :text
       :content-renderer (fn [submission]
                           [:div {}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
@@ -100,7 +100,9 @@
            selected-submission-id (not-empty (:segment nav-context))]
        [:div {:style {:padding "1em"}}
         (if selected-submission-id
-          [submission-details/Page {:workspace-id workspace-id :submission-id selected-submission-id}]
+          [submission-details/Page {:key selected-submission-id
+                                    :workspace-id workspace-id
+                                    :submission-id selected-submission-id}]
           [SubmissionsList {:ref "submissions-list"
                             :workspace-id workspace-id
                             :on-submission-clicked #(nav/navigate nav-context %)}])]))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
@@ -56,9 +56,6 @@
    (fn [{:keys [state this]}]
      (swap! state dissoc :server-response)
      (react/call :load-submissions this))
-   :get-initial-state
-   (fn []
-     {:loading? false})
    :render
    (fn [{:keys [props state]}]
      (let [server-response (:server-response @state)
@@ -70,19 +67,16 @@
          :else
          (render-submissions-table submissions (:on-submission-clicked props)))))
    :component-did-mount
-    (fn [{:keys [this]}]
-      (react/call :load-submissions this))
+   (fn [{:keys [this]}]
+     (react/call :load-submissions this))
    :load-submissions
    (fn [{:keys [props state]}]
-     (when-not (:loading? @state)
-       (swap! state assoc :loading true)
-       (endpoints/call-ajax-orch
-         {:endpoint (endpoints/list-submissions (:workspace-id props))
-          :on-done (fn [{:keys [success? status-text get-parsed-response]}]
-                     (swap! state assoc :server-response (if success?
-                                                           {:submissions (get-parsed-response)}
-                                                           {:error-message status-text}))
-                     (swap! state assoc :loading false))})))})
+     (endpoints/call-ajax-orch
+       {:endpoint (endpoints/list-submissions (:workspace-id props))
+        :on-done (fn [{:keys [success? status-text get-parsed-response]}]
+                   (swap! state assoc :server-response (if success?
+                                                         {:submissions (get-parsed-response)}
+                                                         {:error-message status-text})))}))})
 
 
 (react/defc Page

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/tab.cljs
@@ -8,9 +8,10 @@
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
+    [org.broadinstitute.firecloud-ui.nav :as nav]
     [org.broadinstitute.firecloud-ui.page.workspace.monitor.common :as moncommon]
-    [org.broadinstitute.firecloud-ui.page.workspace.monitor.submission-details
-     :as submission-details]
+    [org.broadinstitute.firecloud-ui.page.workspace.monitor.submission-details :as submission-details]
+    [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
 
 
@@ -86,23 +87,21 @@
 
 
 (react/defc Page
-  {:get-initial-state
-   (fn [{:keys [props]}]
-     {:selected-submission-id (:initial-submission-id props)})
+  {:refresh
+   (fn [{:keys [props refs]}]
+     (let [nav-context (nav/parse-segment (:nav-context props))
+           selected-submission-id (not-empty (:segment nav-context))]
+       (if selected-submission-id
+         (nav/back nav-context)
+         (react/call :reload (@refs "submissions-list")))))
    :render
-   (fn [{:keys [props state]}]
-     [:div {:style {:padding "1em"}}
-      (if-let [sid (:selected-submission-id @state)]
-        [submission-details/Page {:workspace-id (:workspace-id props) :submission-id sid}]
-        [SubmissionsList {:ref "submissions-list"
-                          :workspace-id (:workspace-id props)
-                          :on-submission-clicked #(swap! state assoc :selected-submission-id %)}])])
-   :component-will-receive-props
-   (fn [{:keys [state refs]}]
-     (if (:selected-submission-id @state)
-       (swap! state dissoc :selected-submission-id)
-       (react/call :reload (@refs "submissions-list"))))})
-
-
-(defn render [workspace-id & [submission-id]]
-  [Page {:workspace-id workspace-id :initial-submission-id submission-id}])
+   (fn [{:keys [props]}]
+     (let [workspace-id (:workspace-id props)
+           nav-context (nav/parse-segment (:nav-context props))
+           selected-submission-id (not-empty (:segment nav-context))]
+       [:div {:style {:padding "1em"}}
+        (if selected-submission-id
+          [submission-details/Page {:workspace-id workspace-id :submission-id selected-submission-id}]
+          [SubmissionsList {:ref "submissions-list"
+                            :workspace-id workspace-id
+                            :on-submission-clicked #(nav/navigate nav-context %)}])]))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/workflow_details.cljs
@@ -35,9 +35,8 @@
         (:label props)
         (if (empty? (:data props))
           "None"
-          (style/create-link
-            #(swap! state assoc :expanded (not (:expanded @state)))
-            (if (:expanded @state) "Hide" "Show"))))
+          (style/create-link {:text (if (:expanded @state) "Hide" "Show")
+                              :onClick #(swap! state assoc :expanded (not (:expanded @state)))})))
       (when (:expanded @state)
         [:div {:style {:padding "0.25em 0 0.25em 1em"}}
          (for [[k v] (:data props)]
@@ -52,9 +51,8 @@
    (fn [{:keys [props state]}]
      [:div {:style {:marginTop "1em"}}
       [:div {:style {:display "inline-block" :marginRight "1em"}} (:label props)]
-      (style/create-link
-        #(swap! state assoc :expanded (not (:expanded @state)))
-        (if (:expanded @state) "Hide" "Show"))
+      (style/create-link {:text (if (:expanded @state) "Hide" "Show")
+                          :onClick #(swap! state assoc :expanded (not (:expanded @state)))})
       (when (:expanded @state)
         (map-indexed
           (fn [index data]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
@@ -142,9 +142,8 @@
          (when owner?
            [:span {}
             " ("
-            (style/create-link
-              #(swap! state assoc :editing-acl? true)
-              "Sharing...")
+            (style/create-link {:text "Sharing..."
+                                :onClick #(swap! state assoc :editing-acl? true)})
             ")"])])
       (style/create-section-header "Description")
       (style/create-paragraph

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
@@ -180,7 +180,11 @@
 
 
 (react/defc Summary
-  {:render
+  {:refresh
+   (fn [{:keys [state this]}]
+     (swap! state dissoc :server-response :submission-response)
+     (react/call :load-workspace this))
+   :render
    (fn [{:keys [refs state props this]}]
      (let [server-response (:server-response @state)
            {:keys [workspace submissions billing-projects server-error]} server-response]
@@ -228,7 +232,7 @@
                      (swap! state update-in [:server-response]
                        assoc :server-error status-text)))}))
    :lock-or-unlock
-   (fn [{:keys [props state]} locked-now?]
+   (fn [{:keys [props state this]} locked-now?]
      (swap! state assoc :locking? locked-now?)
      (endpoints/call-ajax-orch
        {:endpoint (endpoints/lock-or-unlock-workspace (:workspace-id props) locked-now?)
@@ -237,24 +241,8 @@
                      (if (and (= status-code 409) (not locked-now?))
                        (js/alert "Could not lock workspace, one or more analyses are currently running")
                        (js/alert (str "Error: " status-text))))
-                   (swap! state #(if success?
-                                  (dissoc % :locking? :server-response :submission-response)
-                                  (dissoc % :locking?))))}))
+                   (swap! state dissoc :locking?)
+                   (react/call :refresh this))}))
    :component-did-mount
    (fn [{:keys [this]}]
-     (react/call :load-workspace this))
-   :component-did-update
-   (fn [{:keys [this state]}]
-     (when (nil? (:server-response @state))
-       (react/call :load-workspace this)))
-   :component-will-receive-props
-   (fn [{:keys [props next-props state this]}]
-     (swap! state dissoc :server-response :submission-response)
      (react/call :load-workspace this))})
-
-
-(defn render [workspace-id on-delete nav-context]
-  (react/create-element Summary {:key workspace-id
-                                 :nav-context nav-context
-                                 :workspace-id workspace-id
-                                 :on-delete on-delete}))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -237,7 +237,7 @@
           [WorkspaceList
            {:onWorkspaceSelected
             (fn [workspace]
-              (nav/navigate nav-context (str (workspace "namespace") ":" (workspace "name")))
+              (nav/navigate nav-context (str (workspace "namespace") ":" (workspace "name")) "Summary")
               (common/scroll-to-top))
             :nav-context nav-context}])]))
    :component-did-mount

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -231,7 +231,7 @@
        [:div {}
         [:div {:style {:padding "2em"}}
          [:span {:style {:fontSize "180%"}}
-          [comps/Breadcrumbs {:ref "breadcrumbs"}]]]
+          [comps/Breadcrumbs {:crumbs (create-breadcrumbs-from-hash (:hash nav-context))}]]]
         (if selected-ws-id
           (render-workspace-details selected-ws-id #(nav/back nav-context) nav-context)
           [WorkspaceList
@@ -239,13 +239,4 @@
             (fn [workspace]
               (nav/navigate nav-context (str (workspace "namespace") ":" (workspace "name")) "Summary")
               (common/scroll-to-top))
-            :nav-context nav-context}])]))
-   :component-did-mount
-   (fn [{:keys [this refs]}]
-     (set! (.-onHashChange this)
-       #(react/call :set-crumbs (@refs "breadcrumbs") (create-breadcrumbs-from-hash (nav/get-hash-value))))
-     ((.-onHashChange this))
-     (.addEventListener js/window "hashchange" (.-onHashChange this)))
-   :component-will-unmount
-   (fn [{:keys [this]}]
-     (.removeEventListener js/window "hashchange" (.-onHashChange this)))})
+            :nav-context nav-context}])]))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -35,8 +35,9 @@
               (when (:creating-wf @state)
                 [comps/Blocker {:banner "Creating Workspace..."}])
               (style/create-form-label "Google Project")
-              (style/create-select {:value (:selected-project @state)
-                                    :onChange #(swap! state assoc :selected-project (-> % .-target .-value))}
+              (style/create-select
+               {:value (:selected-project @state)
+                :onChange #(swap! state assoc :selected-project (-> % .-target .-value))}
                 (:billing-projects props))
               (style/create-form-label "Name")
               [input/TextField {:ref "wsName" :style {:width "100%"}
@@ -77,12 +78,12 @@
   {:render
    (fn [{:keys [props]}]
      (let [status (get-in props [:data :status])]
-       [:div {:style {:backgroundColor (style/color-for-status status)
-                      :margin "2px 0 0 2px" :height "calc(100% - 4px)"
-                      :position "relative" :cursor "pointer"}
-              :onClick #((get-in props [:data :onClick]))}
-        [:div {:style {:backgroundColor "rgba(0,0,0,0.2)"
-                       :position "absolute" :top 0 :right 0 :bottom 0 :left 2}}]
+       [:a {:href (nav/create-href (:nav-context props) (get-in props [:data :href])) 
+            :style {:display "block" :backgroundColor (style/color-for-status status)
+                    :margin "2px 0 0 2px" :height "calc(100% - 4px)"
+                    :position "relative"}}
+        [:span {:style {:display "block" :backgroundColor "rgba(0,0,0,0.2)"
+                        :position "absolute" :top 0 :right 0 :bottom 0 :left 2}}]
         (style/center {}
           (case status
             "Complete" [icons/CompleteIcon]
@@ -93,11 +94,12 @@
 (react/defc WorkspaceCell
   {:render
    (fn [{:keys [props]}]
-     [:div {:style {:backgroundColor (style/color-for-status (get-in props [:data :status]))
-                    :marginTop 2 :height "calc(100% - 4px)"
-                    :color "white" :cursor "pointer"}
-            :onClick #((get-in props [:data :onClick]))}
-      [:div {:style {:padding "1em 0 0 1em" :fontWeight 600}}
+     [:a {:href (nav/create-href (:nav-context props) (get-in props [:data :href]))
+          :style {:display "block"
+                  :backgroundColor (style/color-for-status (get-in props [:data :status]))
+                  :marginTop 2 :height "calc(100% - 4px)"
+                  :color "white" :textDecoration "none"}}
+      [:span {:style {:display "block" :padding "1em 0 0 1em" :fontWeight 600}}
        (get-in props [:data :name])]])})
 
 (defn- get-workspace-name-string [ws]
@@ -150,10 +152,12 @@
          :columns
          [{:sort-by :none :filter-by :none
            :header [:div {:style {:marginLeft -6}} "Status"] :starting-width 60
-           :content-renderer (fn [data] [StatusCell {:data data}])}
+           :content-renderer (fn [data] [StatusCell {:data data
+                                                     :nav-context (:nav-context props)}])}
           {:as-text :name :sort-by :text
            :header "Workspace" :starting-width (* max-workspace-name-length 10)
-           :content-renderer (fn [data] [WorkspaceCell {:data data}])}
+           :content-renderer (fn [data] [WorkspaceCell {:data data
+                                                        :nav-context (:nav-context props)}])}
           {:header "Description" :starting-width (max 200 (* max-description-length 10))
            :content-renderer (fn [description]
                                [:div {:style {:padding "1.1em 0 0 14px"}}
@@ -168,13 +172,12 @@
               (clojure.string/capitalize accessLevel)])}]
          :data (:workspaces props)
          :->row (fn [ws]
-                  [{:status (:status ws)
-                    :onClick #((:onWorkspaceSelected props) (ws "workspace"))}
-                   {:name (get-workspace-name-string ws)
-                    :status (:status ws)
-                    :onClick #((:onWorkspaceSelected props) (ws "workspace"))}
-                   (get-workspace-description ws)
-                   (get-in ws ["accessLevel"])])}]))})
+                  (let [ws-name (get-workspace-name-string ws)
+                        ws-href (let [x (ws "workspace")] (str (x "namespace") ":" (x "name")))]
+                    [{:name ws-name :href ws-href :status (:status ws)}
+                     {:name ws-name :href ws-href :status (:status ws)}
+                     (get-workspace-description ws)
+                     (get-in ws ["accessLevel"])]))}]))})
 
 
 (react/defc WorkspaceList
@@ -187,7 +190,8 @@
          (some nil? [workspaces billing-projects]) [comps/Spinner {:text "Loading workspaces..."}]
          :else
          [:div {:style {:margin "0 2em"}}
-          [WorkspaceTable (assoc props :workspaces workspaces :billing-projects billing-projects)]])))
+          [WorkspaceTable
+           (assoc props :workspaces workspaces :billing-projects billing-projects)]])))
    :component-did-mount
    (fn [{:keys [state]}]
      (endpoints/call-ajax-orch
@@ -233,9 +237,4 @@
           [comps/Breadcrumbs {:crumbs (create-breadcrumbs-from-hash (:hash nav-context))}]]]
         (if selected-ws-id
           (render-workspace-details selected-ws-id #(nav/back nav-context) nav-context)
-          [WorkspaceList
-           {:onWorkspaceSelected
-            (fn [workspace]
-              (nav/navigate nav-context (str (workspace "namespace") ":" (workspace "name")))
-              (common/scroll-to-top))
-            :nav-context nav-context}])]))})
+          [WorkspaceList {:nav-context nav-context}])]))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -215,9 +215,8 @@
   (let [segments (split hash #"/")]
     (map-indexed
       (fn [index segment]
-        (case index
-          0 {:text "Workspaces" :href "#workspaces"}
-          1 {:text (replace (js/decodeURIComponent segment) ":" "/")}
+        (if (zero? index)
+          {:text "Workspaces" :href "#workspaces"}
           {:text (replace (js/decodeURIComponent segment) ":" "/")
            :href (str "#" (join "/" (subvec segments 0 (inc index))))}))
       segments)))
@@ -237,6 +236,6 @@
           [WorkspaceList
            {:onWorkspaceSelected
             (fn [workspace]
-              (nav/navigate nav-context (str (workspace "namespace") ":" (workspace "name")) "Summary")
+              (nav/navigate nav-context (str (workspace "namespace") ":" (workspace "name")))
               (common/scroll-to-top))
             :nav-context nav-context}])]))})


### PR DESCRIPTION
This fixes the visual problem on hot reload, but the click handlers still fail because they refer to old versions of the components. It might be worth making the breadcrumbs control work more like the tab bar   (where it controls the currently-displayed component) to fix this.