### PR TITLE
DSDEEPB-2247: show ErrorViewer when profile fails to save

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/profile.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/profile.cljs
@@ -57,16 +57,18 @@
         (when (:in-progress? @state)
           [components/Spinner {:text "Saving..."}])
         (when (:error-message @state)
-          [:div {:style {:color (:exception-red style/colors)}} (:error-message @state)])]))
+          [:div {}
+            [:div {:style {:color (:exception-red style/colors) :margin "10px 0px"}} (:error-message @state)]
+            [components/ErrorViewer {:error (:server-error @state)}]])]))
    :save
    (fn [{:keys [this props state refs]}]
      (swap! state (fn [s] (assoc (dissoc s :error-message) :in-progress? true)))
      (let [values (react/call :get-values (@refs "form"))]
        (endpoints/profile-set values
-         (fn [{:keys [success?]}]
+         (fn [{:keys [success? get-parsed-response]}]
            (let [new-state (dissoc @state :in-progress?)]
              (if-not success?
-               (reset! state (assoc new-state :error-message "Profile failed to save."))
+               (reset! state (assoc new-state :error-message "Profile failed to save." :server-error (get-parsed-response)))
                (do (reset! state (assoc new-state :done? true))
                  (js/setTimeout (:on-done props) 2000))))))))})
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/profile.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/profile.cljs
@@ -56,19 +56,17 @@
           [:div {:style {:color (:success-green style/colors)}} "Profile saved!"])
         (when (:in-progress? @state)
           [components/Spinner {:text "Saving..."}])
-        (when (:error-message @state)
-          [:div {}
-            [:div {:style {:color (:exception-red style/colors) :margin "10px 0px"}} (:error-message @state)]
-            [components/ErrorViewer {:error (:server-error @state)}]])]))
+        (when (:server-error @state)
+          [components/ErrorViewer {:error (:server-error @state)}])]))
    :save
    (fn [{:keys [this props state refs]}]
-     (swap! state (fn [s] (assoc (dissoc s :error-message) :in-progress? true)))
+     (swap! state (fn [s] (assoc (dissoc s :server-error) :in-progress? true)))
      (let [values (react/call :get-values (@refs "form"))]
        (endpoints/profile-set values
          (fn [{:keys [success? get-parsed-response]}]
            (let [new-state (dissoc @state :in-progress?)]
              (if-not success?
-               (reset! state (assoc new-state :error-message "Profile failed to save." :server-error (get-parsed-response)))
+               (reset! state (assoc new-state :server-error (get-parsed-response)))
                (do (reset! state (assoc new-state :done? true))
                  (js/setTimeout (:on-done props) 2000))))))))})
 


### PR DESCRIPTION
This is in service of DSDEEPB-2247, though it doesn't solve that issue.

Previously, if we encountered an error:
* saving the user profile to Thurloe
* checking for a pre-existing user registration in rawls
* registering the user in rawls
we would display a simple "Profile failed to save" error to the end user.

Now, we add the ErrorViewer to show the error details. This (hopefully) will help end users in debugging any problems they have with registration.