### PR TITLE
Create redact dialog with error message for methods/configs in method repo

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -231,9 +231,10 @@
   {:render
    (fn [{:keys [props]}]
      (when-let [error (:error props)]
-       (let [[source status-code causes stack-trace message]
-             (map error ["source" "statusCode" "causes" "stackTrace" "message"])]
-         (if-let [expected-msg (get-in props [:expect status-code])]
+       (let [[source status-code code causes stack-trace message]
+             (map error ["source" "statusCode" "code" "causes" "stackTrace" "message"])]
+         (if-let [expected-msg (or (get-in props [:expect status-code])
+                                   (get-in props [:expect code]))]
            [:div {}
             [:span {:style {:paddingRight "1ex"}}
              (icons/font-icon {:style {:color (:exception-red style/colors)}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
@@ -1,7 +1,7 @@
 (ns org.broadinstitute.firecloud-ui.page.method-repo
   (:require
    [dmohs.react :as react]
-   [org.broadinstitute.firecloud-ui.page.method-config-importer :refer [MethodConfigImporter]]
+   [org.broadinstitute.firecloud-ui.page.method-repo.method-config-importer :refer [MethodConfigImporter]]
    ))
 
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/methods_configs_acl.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/methods_configs_acl.cljs
@@ -1,4 +1,4 @@
-(ns org.broadinstitute.firecloud-ui.page.methods-configs-acl
+(ns org.broadinstitute.firecloud-ui.page.method-repo.methods-configs-acl
   (:require
    [dmohs.react :as react]
    [clojure.string :refer [trim]]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/redact.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/redact.cljs
@@ -1,0 +1,44 @@
+(ns org.broadinstitute.firecloud-ui.page.method-repo.redact
+  (:require
+    [dmohs.react :as react]
+    [org.broadinstitute.firecloud-ui.common :as common]
+    [org.broadinstitute.firecloud-ui.common.components :as comps]
+    [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
+    [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
+    ))
+
+
+(react/defc Redacter
+  {:render
+   (fn [{:keys [props state this]}]
+     [dialog/Dialog
+      {:width 550
+       :dismiss-self (:dismiss-self props)
+       :content
+       (react/create-element
+         [dialog/OKCancelForm
+          {:header "Confirm redact"
+           :dismiss-self (:dismiss-self props)
+           :content
+           [:div {}
+            (when (:redacting? @state)
+              [comps/Blocker {:banner "Redacting..."}])
+            [:p {} (str "Are you sure you want to redact this method"
+                     (when (:is-config? props) " configuration") "?")]
+            [comps/ErrorViewer {:error (:error @state)
+                                :expect {401 "Unauthorized"}}]]
+           :ok-button [comps/Button {:text "Redact" :onClick #(react/call :redact this)}]}])}])
+   :component-did-mount
+   (fn []
+     (common/scroll-to-top 100))
+   :redact
+   (fn [{:keys [props state]}]
+     (swap! state assoc :redacting? true :error nil)
+     (let [[namespace name snapshotId] (map #(get-in props [:entity %]) ["namespace" "name" "snapshotId"])]
+       (endpoints/call-ajax-orch
+         {:endpoint (endpoints/delete-agora-entity (:is-config? props) namespace name snapshotId)
+          :on-done (fn [{:keys [success? get-parsed-response]}]
+                     (swap! state dissoc :redacting?)
+                     (if success?
+                       ((:on-delete props))
+                       (swap! state assoc :error (get-parsed-response))))})))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
@@ -9,7 +9,7 @@
     [org.broadinstitute.firecloud-ui.common.table :as table]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
     [org.broadinstitute.firecloud-ui.nav :as nav]
-    [org.broadinstitute.firecloud-ui.page.method-config-importer :refer [MethodConfigImporter]]
+    [org.broadinstitute.firecloud-ui.page.method-repo.method-config-importer :refer [MethodConfigImporter]]
     [org.broadinstitute.firecloud-ui.page.workspace.method-configs.method-config-editor :refer [MethodConfigEditor]]
     [org.broadinstitute.firecloud-ui.utils :as utils]
     ))


### PR DESCRIPTION
A few things came up in this:

* The code that @rushtong added for checking 401s seemed to have a bug.  I think it's working right now, but whoever reviews this should take an especially close look at the changes to utils.
* Rawls/Agora return a nice JSON structure for error messages, with "source", "statusCode", "causes", "stackTrace" and "message" fields.  This is what gets passed to the comps/ErrorViewer.  However, the "unauthorized" message is coming back with just "code" and "message".  So an extra field check was added to comps/ErrorViewer, but I suppose it would be better to make the JSON responses consistent.