### PR TITLE
DSDEEPB-1929: use dropdown for root entity type

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -131,3 +131,6 @@
   (when-not (clojure.string/blank? segment)
     (let [[ns n] (clojure.string/split segment #":")]
       {:namespace ns :name n})))
+
+(def root-entity-types
+  '("participant","sample","pair","participant_set","sample_set","pair_set"))

--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -133,4 +133,4 @@
       {:namespace ns :name n})))
 
 (def root-entity-types
-  '("participant","sample","pair","participant_set","sample_set","pair_set"))
+  ["participant" "sample" "pair" "participant_set" "sample_set" "pair_set"])

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
@@ -62,6 +62,10 @@
   [:select (deep-merge {:style select-style} props)
    (map-indexed (fn [i opt] [:option {:value i} opt]) options)])
 
+(defn create-identity-select [props options]
+  [:select (deep-merge {:style select-style} props)
+   (map (fn [opt] [:option {:value opt} opt]) options)])
+
 (defn create-server-error-message [message]
   [:div {:style {:textAlign "center" :color (:exception-red colors)}}
    "FireCloud service returned error: " (or message "(no message provided)")])

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_config_importer.cljs
@@ -54,12 +54,12 @@
             (style/create-form-label (:label field))
               (cond (= (:type field) "identity-select")
                 (style/create-identity-select {:ref (:key field)
-                  :value (entity (:key field))}
-                  root-entity-types)
+                                               :value (entity (:key field))}
+                                              (:options field))
                 :else
                   [input/TextField {:defaultValue (entity (:key field))
-                    :ref (:key field) :placeholder "Required"
-                    :predicates [(input/nonempty "Fields")]}])])
+                                    :ref (:key field) :placeholder "Required"
+                                    :predicates [(input/nonempty "Fields")]}])])
        fields)
      (clear-both)
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
@@ -162,9 +162,9 @@
      (create-section
        (if editing?
          (style/create-identity-select {:ref "rootentitytype"
-                               :defaultValue (config "rootEntityType")
-                               :style {:width "500px"}}
-                              root-entity-types)
+                                        :defaultValue (config "rootEntityType")
+                                        :style {:width "500px"}}
+                                       root-entity-types)
          [:div {:style {:padding "0.5em 0 1em 0"}} (config "rootEntityType")]))
      (create-section-header "Inputs")
      (input-output-list config "inputs" invalid-inputs editing?)

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
@@ -2,7 +2,7 @@
   (:require
     [dmohs.react :as react]
     [clojure.string :refer [trim blank?]]
-    [org.broadinstitute.firecloud-ui.common :refer [clear-both get-text]]
+    [org.broadinstitute.firecloud-ui.common :refer [clear-both get-text root-entity-types]]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
     [org.broadinstitute.firecloud-ui.common.icons :as icons]
@@ -161,8 +161,10 @@
      (create-section-header "Root Entity Type")
      (create-section
        (if editing?
-         (style/create-text-field {:ref "rootentitytype" :style {:width 500}
-                                   :defaultValue (config "rootEntityType")})
+         (style/create-identity-select {:ref "rootentitytype"
+                               :defaultValue (config "rootEntityType")
+                               :style {:width "500px"}}
+                              root-entity-types)
          [:div {:style {:padding "0.5em 0 1em 0"}} (config "rootEntityType")]))
      (create-section-header "Inputs")
      (input-output-list config "inputs" invalid-inputs editing?)


### PR DESCRIPTION
Manually tested:
* editing a config that pre-existed in your workspace
* importing a method from agora
* importing a config from agora

(note that in the last use case, you do not have the option of changing the root entity type; I tested this to ensure there was no regression)

At the code level, I don't like having both style/create-select and style/create-identity-select; these could be refactored back into a single function, but doing so opens a large-ish risk of regression.