### PR TITLE
killed box-shadow

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
@@ -36,7 +36,7 @@
   {:backgroundColor "#fff"
    ;; Split out border properties so they can be individually overridden
    :borderWidth 1 :borderStyle "solid" :borderColor (:border-gray colors) :borderRadius 3
-   :boxShadow "0px 1px 3px rgba(0,0,0,0.06)" :boxSizing "border-box"
+   :boxSizing "border-box"
    :fontSize "88%"
    :marginBottom "0.75em" :padding "0.5em"})
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/table_utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/table_utils.cljs
@@ -44,7 +44,7 @@
            allow-next (< current-page num-pages)
            right-num (min num-rows-visible (* current-page rows-per-page))
            left-num (if (zero? right-num) 0 (inc (* (dec current-page) rows-per-page)))]
-       [:div {:style {:border "1px solid #ebebeb" :boxShadow "-3px -6px 23px -7px #ebebeb inset"}}
+       [:div {:style {:border "1px solid #ebebeb"}}
         (let [layout-style (if (= :narrow (:width props))
                              {:textAlign "center" :padding "1ex"}
                              {:float "left" :width "33.33%"})


### PR DESCRIPTION
Removed box-shadow from table paginator because it looks weird. It's also not used anywhere else except text boxes, and only very subtly -- so I removed it there too.

This code is released under the terms of the [Unlicense](http://unlicense.org/) (i.e. all rights waived, all uses permitted, software released as-is, no holding me liable).