### PR TITLE
DSDEEPB-2248: use version number for Thurloe profile instead of true/false

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/endpoints.cljs
@@ -545,7 +545,7 @@
        {:userId "55"
         :keyValuePairs
         (map (fn [[k v]] {:key k :value v})
-             {:isRegistrationComplete "true" :name "John Doe" :email "jdoe@example.com"
+             {:isRegistrationComplete "1" :name "John Doe" :email "jdoe@example.com"
               :googleProjectIds ["14" "7"] :institution "Broad Institute"
               :pi "Jane Doe"})})}}
      :service-prefix "/service/register")))

--- a/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
@@ -149,7 +149,7 @@
         (fn [{:keys [success? status-text get-parsed-response]}]
           (let [parsed-values (when success? (common/parse-profile (get-parsed-response)))]
             (cond
-              (and success? (= (:isRegistrationComplete parsed-values) "true"))
+              (and success? (>= (int (:isRegistrationComplete parsed-values)) 1))
               (swap! state assoc :registration-status :registered :name (:name parsed-values))
               success? ; partial profile case
               (swap! state assoc :registration-status :not-registered)


### PR DESCRIPTION
now, when we check the user's profile in Thurloe, we read a version number instead of a true/false indicator. This allows us to change the profile fields over time.

we rely on cljs to return 0 when casting "true" to int.
