### PR TITLE
Change the display of submission status counts

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
@@ -12,7 +12,7 @@
     [org.broadinstitute.firecloud-ui.page.workspace.summary.acl-editor :refer [AclEditor]]
     [org.broadinstitute.firecloud-ui.page.workspace.summary.attribute-editor :as attributes]
     [org.broadinstitute.firecloud-ui.page.workspace.summary.workspace-cloner :refer [WorkspaceCloner]]
-    ))
+    [org.broadinstitute.firecloud-ui.utils :as utils]))
 
 
 (defn- render-tags [tags]
@@ -170,12 +170,12 @@
          (get-in ws ["workspace" "bucketName"])])
       (style/create-section-header "Analysis Submissions")
       (style/create-paragraph
-        (let [fail-count (->> submissions
-                           (filter (complement all-success?))
-                           count)]
-          (str (count submissions) " Submissions"
-            (when (pos? fail-count)
-              (str " (" fail-count " failed)")))))]]))
+        (let [workflows (flatten (map #(get-in % ["workflows"]) submissions))
+              statuses (map #(% "status") workflows)
+              frequencies (into (sorted-map-by <) (frequencies statuses))]
+             [:div {}
+              (str (count submissions) " Submissions")
+              [:ul {} (map (fn [[k v]] [:li {} (str k ": " v)]) frequencies)]]))]]))
 
 
 (react/defc Summary


### PR DESCRIPTION
I changed the approach to show all of the submission statuses with their associated count values. This should account for any kind of status that might come down the pike and doesn't depend on a pre-determined list.