### PR TITLE
use supported url for GCS downloads

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common.cljs
@@ -100,7 +100,7 @@
           :else "Complete")))
 
 (defn gcs-object->download-url [bucket object]
-  (str "https://console.cloud.google.com/m/cloudstorage/b/" bucket "/o/" object))
+  (str "https://storage.cloud.google.com/" bucket "/" object))
 
 (defn gcs-uri->download-url [gcs-uri]
   (let [matcher (re-find #"gs://([^/]+)/(.+)" gcs-uri)]


### PR DESCRIPTION
a la https://cloud.google.com/storage/docs/authentication#cookieauth

This does not attempt to address DSDEEPB-2380. It's simply about putting us on a supported url format instead of an unsupported reverse-engineered url format.
