### PR TITLE
DSDEEPB-1530/2052: Method importer/exporter improvements

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -37,7 +37,8 @@
             :onClick (if disabled?
                        #(js/alert (if (string? disabled?) disabled? "This action is disabled"))
                        (when-let [on-click (:onClick props)] #(on-click %)))
-            :onKeyDown (when-not disabled? (common/create-key-handler [:space :enter] (:onClick props)))}
+            :onKeyDown (when (and (:onClick props) (not disabled?))
+                         (common/create-key-handler [:space :enter] (:onClick props)))}
         (or (:text props) (icons/icon-text (:icon props)))
         (when (= (:style props) :add)
           [:span {:style {:display "inline-block" :height "1em" :width "1em" :marginLeft "1em"
@@ -165,24 +166,24 @@
                       :padding "1em"}}
         (react/call :render-details this make-field entity)
         [:div {:style {:paddingTop "0.5em"}}
-         [:span {:style {:fontWeight 500 :marginRight "1em"}} (if config? "Referenced Method:" "Payload:")]
+         [:span {:style {:fontWeight 500 :marginRight "1em"}} (if config? "Referenced Method:" "WDL:")]
          (style/create-link {:text (if (:payload-expanded @state) "Collapse" "Expand")
                              :onClick #(swap! state assoc :payload-expanded (not (:payload-expanded @state)))})]
         (when (:payload-expanded @state)
           (if config?
             [:div {:style {:margin "0.5em 0 0 1em"}}
              (react/call :render-details this make-field (entity "method"))
-             [:div {:style {:fontWeight 500 :marginTop "1em"}} "Payload:"]
-             [:pre {:style {:fontSize "90%"}} (get-in entity ["method" "payload"])]]
-            [:pre {:style {:fontSize "90%"}} (entity "payload")]))]))
+             [:div {:style {:fontWeight 500 :marginTop "1em"}} "WDL:"]
+             [:pre {:style {:fontSize "90%" :overflow "auto"}} (get-in entity ["method" "payload"])]]
+            [:pre {:style {:fontSize "90%" :overflow "auto"}} (entity "payload")]))]))
    :render-details
    (fn [{:keys []} make-field entity]
      [:div {}
-      [:div {:style {:float "left"}}
+      [:div {:style {:float "left" :marginRight "5em"}}
        (make-field entity "namespace" "Namespace: ")
        (make-field entity "name" "Name: ")
        (make-field entity "snapshotId" "Snapshot ID: ")]
-      [:div {:style {:float "left" :marginLeft "5em"}}
+      [:div {:style {:float "left"}}
        (make-field entity "createDate" "Created: " common/format-date)
        (make-field entity "entityType" "Entity Type: ")
        (make-field entity "synopsis" "Synopsis: ")]

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/dialog.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/dialog.cljs
@@ -82,7 +82,7 @@
                :href "javascript:;"
                :onClick #((:dismiss-self props))
                :onKeyDown (common/create-key-handler [:space :enter] #((:dismiss-self props)))}
-           "Cancel"])
+           (or (:cancel-text props) "Cancel")])
         (:ok-button props)]]])})
 
 

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
@@ -40,16 +40,15 @@
    ;; Split out border properties so they can be individually overridden
    :borderWidth 1 :borderStyle "solid" :borderColor (:border-gray colors) :borderRadius 3
    :boxSizing "border-box"
-   :fontSize "88%"
+   :fontSize "88%" :height 33
    :marginBottom "0.75em" :padding "0.5em"})
 
 (def ^:private select-style
   {:backgroundColor "#fff"
    ;; Split out border properties so they can be individually overridden
    :borderWidth 1 :borderStyle "solid" :borderColor (:border-gray colors) :borderRadius 2
-   :color "#000"
-   :marginBottom "0.75em" :padding "0.33em 0.5em"
-   :width "100%" :fontSize "88%"})
+   :color "#000" :height 33 :width "100%" :fontSize "88%"
+   :marginBottom "0.75em" :padding "0.33em 0.5em"})
 
 
 (defn create-form-label [text]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_config_importer.cljs
@@ -54,53 +54,59 @@
     [:div {}
      (when (:blocking-text @state)
        [comps/Blocker {:banner (:blocking-text @state)}])
-     [:div {:style {:marginBottom "1em" :width 290}}
-      (when (:show-perms-overlay? @state)
-        [mca/AgoraPermsEditor {:is-conf config? :selected-entity entity
-                               :dismiss-self #(swap! state dissoc :show-perms-overlay?)}])
-      (when (:show-redact-overlay? @state)
-        [Redactor {:dismiss #(swap! state dissoc :show-redact-overlay?)
-                   :entity entity :config? config? :on-delete (:on-delete props)}])
-      [comps/SidebarButton {:style :light :margin :top :color :button-blue
-                            :text "Permissions..." :icon :gear
-                            :onClick #(swap! state assoc :show-perms-overlay? true)}]
-      [comps/SidebarButton
-       {:style :light :margin :top :color :exception-red
-        :text "Redact" :icon :trash-can
-        :onClick #(swap! state assoc :show-redact-overlay? true)}]]
+     (when (:show-perms-overlay? @state)
+       [mca/AgoraPermsEditor {:is-conf config? :selected-entity entity
+                              :dismiss-self #(swap! state dissoc :show-perms-overlay?)}])
+     (when (:show-redact-overlay? @state)
+       [Redactor {:dismiss #(swap! state dissoc :show-redact-overlay?)
+                  :entity entity :config? config? :on-delete (:on-delete props)}])
      [comps/EntityDetails {:entity entity}]
-     [:div {:style {:fontSize "120%" :margin "1.5em 0 0.5em 0"}} "Save as:"]
-     (map
-       (fn [field]
-         [:div {:style {:float "left" :marginRight "0.5em"}}
-            (style/create-form-label (:label field))
-              (cond (= (:type field) "identity-select")
-                (style/create-identity-select {:ref (:key field)
-                                               :value (entity (:key field))}
-                                              (:options field))
-                :else
-                  [input/TextField {:defaultValue (entity (:key field))
-                                    :ref (:key field) :placeholder "Required"
-                                    :predicates [(input/nonempty "Fields")]}])])
-       fields)
-     (clear-both)
-
-     (when-not workspace-id
-       [:div {:style {:marginBottom "1em"}}
-        [:div {:style {:fontSize "120%" :margin "1em 0"}} "Destination Workspace:"]
-        (style/create-select
-          {:ref "workspace-id"
-           :style {:width 300}
-           :onChange (fn [event]
-                       (swap! state assoc :selected-workspace
-                                   (nth workspaces-list (js/parseInt (.-value (.-target event))))))}
-          (map
-            (fn [ws] (str (get-in ws ["workspace" "namespace"]) "/" (get-in ws ["workspace" "name"])))
-            workspaces-list))])
-     (style/create-validation-error-message (:validation-error @state))
-     [comps/ErrorViewer {:error (:server-error @state)}]
-     [comps/Button {:text (if workspace-id "Import" "Export")
-                    :onClick #(react/call :perform-copy this)}]]))
+     (when (:allow-edit props)
+       [:div {:style {:margin "1em 0"}}
+        [:div {:style {:float "left" :width 290 :paddingRight "1em"}}
+         [comps/SidebarButton {:style :light :color :button-blue
+                               :text "Permissions..." :icon :gear
+                               :onClick #(swap! state assoc :show-perms-overlay? true)}]]
+        [:div {:style {:float "left" :width 290}}
+         [comps/SidebarButton {:style :light :color :exception-red
+                               :text "Redact" :icon :trash-can
+                               :onClick #(swap! state assoc :show-redact-overlay? true)}]]
+        (clear-both)])
+     [:div {:style {:border (str "1px solid " (:line-gray style/colors))
+                    :backgroundColor (:background-gray style/colors)
+                    :borderRadius 8 :padding "1em" :marginTop "1em"}}
+      [:div {:style {:fontSize "120%" :marginBottom "0.5em"}}
+       (if workspace-id "Import as:" "Export to Workspace as:")]
+      (map
+        (fn [field]
+          [:div {:style {:float "left" :marginRight "0.5em"}}
+           (style/create-form-label (:label field))
+           (cond (= (:type field) "identity-select")
+             (style/create-identity-select {:ref (:key field)
+                                            :value (entity (:key field))}
+               (:options field))
+             :else
+             [input/TextField {:defaultValue (entity (:key field))
+                               :ref (:key field) :placeholder "Required"
+                               :predicates [(input/nonempty "Fields")]}])])
+        fields)
+      (clear-both)
+      (when-not workspace-id
+        [:div {:style {:marginBottom "1em"}}
+         [:div {:style {:fontSize "120%" :margin "1em 0"}} "Destination Workspace:"]
+         (style/create-select
+           {:ref "workspace-id"
+            :style {:width 300}
+            :onChange (fn [event]
+                        (swap! state assoc :selected-workspace
+                          (nth workspaces-list (js/parseInt (.-value (.-target event))))))}
+           (map
+             (fn [ws] (str (get-in ws ["workspace" "namespace"]) "/" (get-in ws ["workspace" "name"])))
+             workspaces-list))])
+      (style/create-validation-error-message (:validation-error @state))
+      [comps/ErrorViewer {:error (:server-error @state)}]
+      [comps/Button {:text (if workspace-id "Import" "Export")
+                     :onClick #(react/call :perform-copy this)}]]]))
 
 
 (react/defc ConfigImportForm
@@ -137,11 +143,8 @@
               :on-done (fn [{:keys [success? get-parsed-response]}]
                          (swap! state dissoc :blocking-text)
                          (if success?
-                           (do
-                             (on-back)
-                             (common/scroll-to-top)
-                             (when after-import (after-import {"namespace" namespace
-                                                               "name" name})))
+                           (when after-import (after-import {:config-id {:namespace namespace :name name}
+                                                             :workspace-id workspace-id}))
                            (swap! state assoc :server-error (get-parsed-response))))})))))
    :component-did-mount
    (fn [{:keys [props state]}]
@@ -200,11 +203,8 @@
               :on-done (fn [{:keys [success? get-parsed-response]}]
                          (swap! state dissoc :blocking-text)
                          (if success?
-                           (do
-                             (on-back)
-                             (common/scroll-to-top)
-                             (when after-import (after-import {"namespace" namespace
-                                                               "name" name})))
+                           (when after-import (after-import {:config-id {:namespace namespace :name name}
+                                                             :workspace-id workspace-id}))
                            (swap! state assoc :server-error (get-parsed-response))))})))))
    :component-did-mount
    (fn [{:keys [props state]}]
@@ -322,6 +322,7 @@
                               (react/call :reload (@refs "table")))
                  item-type (:selected-item @state)
                  :workspace-id (:workspace-id props)
+                 :allow-edit (:allow-edit props)
                  :on-back #(swap! state dissoc :selected-item)
                  :after-import (:after-import props)}]))
       [Table {:ref "table"

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo.cljs
@@ -1,12 +1,36 @@
 (ns org.broadinstitute.firecloud-ui.page.method-repo
   (:require
    [dmohs.react :as react]
+   [org.broadinstitute.firecloud-ui.common :as common]
+   [org.broadinstitute.firecloud-ui.common.components :as comps]
+   [org.broadinstitute.firecloud-ui.common.dialog :as dialog]
    [org.broadinstitute.firecloud-ui.page.method-config-importer :refer [MethodConfigImporter]]
+   [org.broadinstitute.firecloud-ui.nav :as nav]
+   [org.broadinstitute.firecloud-ui.utils :as utils]
    ))
 
 
 (react/defc Page
   {:render
-   (fn []
+   (fn [{:keys [state]}]
      [:div {:style {:padding "1em"}}
-      [MethodConfigImporter {}]])})
+      (when (:destination @state)
+        [dialog/Dialog
+         {:dismiss-self #(swap! state dissoc :destination)
+          :width 500
+          :content
+          (react/create-element
+            [dialog/OKCancelForm
+             {:dismiss-self #(swap! state dissoc :destination)
+              :header "Import successful"
+              :content "Would you like to go to the edit page now?"
+              :cancel-text "No, stay here"
+              :ok-button [comps/Button {:text "Yes" :href (:destination @state)}]}])}])
+      [MethodConfigImporter {:allow-edit true
+                             :after-import (fn [{:keys [workspace-id config-id]}]
+                                             (common/scroll-to-top 100)
+                                             (swap! state assoc
+                                               :destination (str "#workspaces/"
+                                                              (:namespace workspace-id) "%3A" (:name workspace-id)
+                                                              "/Method%20Configurations/"
+                                                              (:namespace config-id) "%3A" (:name config-id))))}]])})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/methods_configs_acl.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/methods_configs_acl.cljs
@@ -90,6 +90,7 @@
            :ok-button [comps/Button {:text "Save" :onClick #(react/call :persist-acl this)}]}])}])
    :component-did-mount
    (fn [{:keys [props state]}]
+     (common/scroll-to-top 100)
      (endpoints/call-ajax-orch
        {:endpoint (let [[name nmsp sid] (map (:selected-entity props) ["name" "namespace" "snapshotId"])]
                     (endpoints/get-agora-method-acl nmsp name sid (:is-conf props)))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
@@ -39,9 +39,9 @@
                      [:div {:style {:padding "1em"}}
                       [comps/XButton {:dismiss #(swap! state dissoc :show-import-overlay?)}]
                       [MethodConfigImporter {:workspace-id (:workspace-id props)
-                                             :after-import (fn [config]
+                                             :after-import (fn [{:keys [config-id]}]
                                                              (swap! state dissoc :show-import-overlay?)
-                                                             ((:on-config-imported props) (config->id config)))}]])}])
+                                                             ((:on-config-imported props) config-id))}]])}])
       (let [server-response (:server-response @state)
             {:keys [configs error-message]} server-response]
         (cond


### PR DESCRIPTION
- "Payload" -> "WDL"
- Fixed overflow problems with wide WDL
- Move "Permissions" and "Redact" buttons below summary, and hide when importing from a workspace
- Visually group import/export fields and adjust wording
- From Method Repo, successful import now opens a dialog asking to stay in the Repo or go to the edit page within the destination workspace
