### PR TITLE
GAWB-3: Just display the stupid message.

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
@@ -70,7 +70,7 @@
 
 (defn create-server-error-message [message]
   [:div {:style {:textAlign "center" :color (:exception-red colors)}}
-   "FireCloud error: " (or message "(no message provided)")])
+   message])
 
 (defn create-validation-error-message [fails]
   [:div {:style {:color (:exception-red colors)}}


### PR DESCRIPTION
This may cause cosmetic problems if the status text of other errors is missing or insufficient, but we are considering that to be a separate issue.
