### PR TITLE
Two quick fixes for stupid bugs I introduced

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
@@ -40,7 +40,7 @@
    ;; Split out border properties so they can be individually overridden
    :borderWidth 1 :borderStyle "solid" :borderColor (:border-gray colors) :borderRadius 3
    :boxSizing "border-box"
-   :fontSize "88%" :height 33
+   :fontSize "88%"
    :marginBottom "0.75em" :padding "0.5em"})
 
 (def ^:private select-style

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspaces_list.cljs
@@ -163,7 +163,7 @@
            :header "Workspace" :starting-width (min 500 (* max-workspace-name-length 10))
            :content-renderer (fn [data] [WorkspaceCell {:data data
                                                         :nav-context (:nav-context props)}])}
-          {:header "Description" :starting-width (max 200 (* max-description-length 10))
+          {:header "Description" :starting-width (min 500 (* max-description-length 10))
            :content-renderer (fn [description]
                                [:div {:style {:padding "0 0 16px 14px"}}
                                 (if description description


### PR DESCRIPTION
- Now properly capping initial workspace description column width in main workspace list
- Undid change to text input styling that broke the text areas for workspace description
