### PR TITLE
remove the token cookie from the proper domain

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -77,7 +77,7 @@
 (def access-token (atom nil))
 
 (defn delete-access-token-cookie []
-  (.remove goog.net.cookies "FCtoken"))
+  (.remove goog.net.cookies "FCtoken" "/" (join "." (rest (split js/window.location.hostname ".")))))
 
 (defn set-access-token-cookie [token]
   (if token


### PR DESCRIPTION
This fixes a regression from https://github.com/broadinstitute/firecloud-ui/pull/403. In this current PR, we delete the auth token cookie from the same domain/path that we set it. Without this PR, we don't delete the cookie, which - in theory - can cause an infinite redirect on login. I can't test this well, because the dev env appears to be down.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] **Submitter**: Tell tech lead that the PR exists if s/he wants to look at it
- [x] **Submitter**: Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] **Tech lead**: sign off
- [x] **LR**: sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: Verify swagger UI on dev server still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
