### PR TITLE
GAWB-735: Show dialog when anything returns 503

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/dialog.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/dialog.cljs
@@ -16,26 +16,26 @@
       :cycle-focus? false})
    :render
    (fn [{:keys [props state]}]
-     (let [content (:content props)
-           anchored? (not (nil? (:get-anchor-dom-node props)))]
+     (let [{:keys [content width blocking? dismiss-self get-anchor-dom-node]} props
+           anchored? (not (nil? get-anchor-dom-node))]
        (assert (react/valid-element? content)
          (subs (str "Not a react element: " content) 0 200))
        (when (or (not anchored?) (:position @state))
-         [:div {:style {:backgroundColor (if (:blocking? props)
+         [:div {:style {:backgroundColor (if blocking?
                                            "rgba(110, 110, 110, 0.4)"
                                            "rgba(210, 210, 210, 0.4)")
                         :position "absolute" :zIndex 8888
                         :top 0 :left 0 :right 0 :height (.. js/document -body -offsetHeight)}
-                :onKeyDown (common/create-key-handler [:esc] #((:dismiss-self props)))
-                :onClick (when-not (:blocking? props) #((:dismiss-self props)))}
+                :onKeyDown (common/create-key-handler [:esc] dismiss-self)
+                :onClick (when-not blocking? dismiss-self)}
           [:div {:style (if anchored?
                           {:position "absolute" :backgroundColor "#fff"
                            :top (get-in @state [:position :top])
                            :left (get-in @state [:position :left])}
                           {:transform "translate(-50%, 0px)" :backgroundColor "#fff"
                            :position "relative" :marginBottom 60
-                           :top 60 :left "50%" :width (:width props)})
-                 :onClick (when-not (:blocking? props) #(.stopPropagation %))}
+                           :top 60 :left "50%" :width width})
+                 :onClick (when-not blocking? #(.stopPropagation %))}
            content]])))
    :component-did-mount
    (fn [{:keys [this props state]}]
@@ -68,24 +68,25 @@
      {:show-cancel? true})
    :render
    (fn [{:keys [props]}]
-     [:div {}
-      [:div {:style {:borderBottom style/standard-line
-                     :padding "20px 48px 18px"
-                     :fontSize "137%" :fontWeight 400 :lineHeight 1}}
-       (:header props)]
-      [:div {:style {:padding "22px 48px 40px" :backgroundColor (:background-gray style/colors)}}
-       (:content props)
-       [:div {:style {:marginTop 40 :textAlign "center"}}
-        (when (:show-cancel? props)
-          [:a {:style {:marginRight 27 :marginTop 2 :padding "0.5em"
-                       :display "inline-block"
-                       :fontSize "106%" :fontWeight 500 :textDecoration "none"
-                       :color (:button-blue style/colors)}
-               :href "javascript:;"
-               :onClick #((:dismiss-self props))
-               :onKeyDown (common/create-key-handler [:space :enter] #((:dismiss-self props)))}
-           (or (:cancel-text props) "Cancel")])
-        (:ok-button props)]]])})
+     (let [{:keys [header content dismiss-self ok-button show-cancel? cancel-text]} props]
+       [:div {}
+        [:div {:style {:borderBottom style/standard-line
+                       :padding "20px 48px 18px"
+                       :fontSize "137%" :fontWeight 400 :lineHeight 1}}
+         header]
+        [:div {:style {:padding "22px 48px 40px" :backgroundColor (:background-gray style/colors)}}
+         content
+         [:div {:style {:marginTop 40 :textAlign "center"}}
+          (when show-cancel?
+            [:a {:style {:marginRight 27 :marginTop 2 :padding "0.5em"
+                         :display "inline-block"
+                         :fontSize "106%" :fontWeight 500 :textDecoration "none"
+                         :color (:button-blue style/colors)}
+                 :href "javascript:;"
+                 :onClick dismiss-self
+                 :onKeyDown (common/create-key-handler [:space :enter] dismiss-self)}
+             (or cancel-text "Cancel")])
+          ok-button]]]))})
 
 
 (react/defc GCSFilePreviewLink

--- a/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
@@ -339,10 +339,11 @@
       (footer)])
    :component-did-mount
    (fn [{:keys [this state]}]
+     ;; pop up the message only when we start getting 503s, not on every 503
      (add-watch
        utils/server-down? :server-watcher
-       (fn [_ _ _ ns]
-         (when ns
+       (fn [_ _ _ down-now?]
+         (when down-now?
            (swap! state assoc :show-server-down-message? true))))
      (react/call :load-config this))
    :component-will-unmount

--- a/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
@@ -339,10 +339,11 @@
       (footer)])
    :component-did-mount
    (fn [{:keys [this state]}]
-     (add-watch utils/server-down? :server-watcher
-                (fn [_ _ os ns]
-                  (when (and ns (not os))
-                    (swap! state assoc :show-server-down-message? true))))
+     (add-watch
+       utils/server-down? :server-watcher
+       (fn [_ _ _ ns]
+         (when ns
+           (swap! state assoc :show-server-down-message? true))))
      (react/call :load-config this))
    :component-will-unmount
    (fn [{:keys [locals]}]

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -138,6 +138,9 @@
             (.send xhr)))))))
 
 
+(defonce server-down? (atom false))
+
+
 (defn ajax-orch [path arg-map & {:keys [service-prefix ignore-auth-expiration?] :or {service-prefix "/api"}}]
   (assert (= (subs path 0 1) "/") (str "Path must start with '/': " path))
   (let [on-done (:on-done arg-map)]
@@ -146,6 +149,7 @@
            :headers (merge {"Authorization" (str "Bearer " @access-token)}
                            (:headers arg-map))
            :on-done (fn [{:keys [status-code] :as m}]
+                      (reset! server-down? (= status-code 503))
                       ;; Handle auth token expiration
                       (if (and (= status-code 401) (not ignore-auth-expiration?))
                         (do (delete-access-token-cookie)

--- a/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/utils.cljs
@@ -149,7 +149,8 @@
            :headers (merge {"Authorization" (str "Bearer " @access-token)}
                            (:headers arg-map))
            :on-done (fn [{:keys [status-code] :as m}]
-                      (reset! server-down? (= status-code 503))
+                      (when (not= @server-down? (= status-code 503))
+                        (swap! server-down? not))
                       ;; Handle auth token expiration
                       (if (and (= status-code 401) (not ignore-auth-expiration?))
                         (do (delete-access-token-cookie)


### PR DESCRIPTION
Right now there isn't any useful information in the 503, so the message is sorta generic.  The load balancing work will address this, at which point we can make the message nicer.

Note: I tested this locally by changing "503" to other things.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] **Submitter**: Tell tech lead that the PR exists if s/he wants to look at it
- [x] **Submitter**: Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] **Tech lead**: sign off
- [x] **LR**: sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't 
  working for ANY reason!
- [x] **Submitter**: Verify swagger UI on dev server still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
