### PR TITLE
Update entity metadata handling in one forgotten place

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/copy_data_entities.cljs
@@ -66,13 +66,13 @@
        (:server-error @state) [comps/ErrorViewer {:error (:server-error @state)}]
        :else [:div {:style {:textAlign "center"}} [comps/Spinner {:text "Loading entities..."}]]))
    :component-did-mount
-   (fn [{:keys [props this]}]
+   (fn [{:keys [this]}]
      (react/call :load-entities this))
    :load-entities
    (fn [{:keys [state props]}]
      (endpoints/call-ajax-orch
        {:endpoint (endpoints/get-entities-of-type (:selected-workspace-id props) (:type props))
-        :on-done (fn [{:keys [success? get-parsed-response status-text]}]
+        :on-done (fn [{:keys [success? get-parsed-response]}]
                    (if success?
                      (swap! state assoc :entity-list (get-parsed-response))
                      (swap! state assoc :server-error (get-parsed-response))))}))})
@@ -90,7 +90,7 @@
           [:h3 {} "Choose type:"]
           [:div {}
            (map
-             (fn [[type count]]
+             (fn [[type {:strs [count]}]]
                [:div {:style {:display "inline-block" :margin "0px 1em"}}
                 [comps/Button {:text (str type " (" count ")")
                                :onClick #((:add-crumb props) {:text type})}]])


### PR DESCRIPTION
Whoops.  I guess this just shows how nobody uses copy-data-between-workspaces, at least not in dev.

The entity selection widget also uses the non-paginated endpoint, though at least right now it's pretty snappy even with 12k entities.  It needs some love though.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] **Submitter**: Tell tech lead that the PR exists if s/he wants to look at it
- [x] **Submitter**: Anoint a lead reviewer (LR). **Assign PR to LR**
- [ ] **LR**: Initial review by LR and others.
- [ ] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] **Tech lead**: sign off
- [ ] **LR**: sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Squash commits, rebase if necessary
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Merge to develop 
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: Check configuration files in Jenkins in case they need changes
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't 
  working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev server still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
