### PR TITLE
fix create-link to allow other attributes

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/style.cljs
@@ -94,11 +94,10 @@
                              :KhtmlUserSelect "none" :MsUserSelect "none"}} props)
    children])
 
-(defn create-link [{:keys [href style onClick text]}]
-  [:a (merge
-        {:href (or href "javascript:;")
-         :style (merge {:textDecoration "none" :color (:button-blue colors)} style)}
-        (when onClick {:onClick onClick}))
+(defn create-link [{:keys [text] :as attributes}]
+  [:a (deep-merge {:href "javascript:;"
+                   :style {:textDecoration "none" :color (:button-blue colors)}}
+                  (dissoc attributes :text))
    text])
 
 (defn render-entity [namespace name snapshot-id]

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
@@ -167,7 +167,6 @@
           true (style/create-link {:text (get-in ws ["workspace" "bucketName"])
                                    :href (str "https://console.developers.google.com/storage/browser/" (get-in ws ["workspace" "bucketName"]) "/")
                                    :title "Click to open the Google Cloud Storage browser for this bucket"
-                                   :style {:textDecoration "none" :color (:button-blue style/colors)}
                                    :target "_blank"})
           false (get-in ws ["workspace" "bucketName"])))
       (style/create-section-header "Analysis Submissions")


### PR DESCRIPTION
The `:title` key wasn't working because it wasn't a recognized parameter in create-link.  The right way is to provide default href and style using deep-merge.
