### PR TITLE
GAWB-1038: put 'select tracks' button back

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/details.cljs
@@ -143,7 +143,9 @@
                            [monitor-tab/Page {:ref MONITOR
                                               :workspace-id workspace-id
                                               :nav-context (nav/terminate-when (not= tab MONITOR) nav-context)}])
-                         :onTabRefreshed #(react/call :refresh (@refs MONITOR))}]}]]))
+                         :onTabRefreshed #(react/call :refresh (@refs MONITOR))}]
+                       :toolbar-right (when-let [analysis-tab (:analysis-tab @state)]
+                                        (react/call :get-tracks-button analysis-tab))}]]))
    :component-did-update
    (fn [{:keys [prev-state state refs]}]
      ;; when switching to the analysis tab, grab the ref to it so we can access the track picker button


### PR DESCRIPTION
Must have been a bad merge at some point.
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  - Acceptance criteria exists and is met
  - Note any changes to implementation from the description
  - Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  - Authentication
  - Authorization
  - Encryption
  - Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- Review cycle:
  - LR reviews
  - Rest of team may comment on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH
  - Submitter updates documentation as needed
  - Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Squash commits and merge to develop
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
