### PR TITLE
Install devtools correctly

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,8 +14,7 @@
   :plugins [[lein-cljsbuild "1.1.2"] [lein-figwheel "0.5.0-5"] [lein-resource "15.10.2"]]
   :profiles {:dev {:dependencies [[binaryage/devtools "0.8.2"]]
                    :cljsbuild
-                   {:builds {:client {:preloads [devtools.preload]
-                                      :source-paths ["src/cljsdev"]
+                   {:builds {:client {:source-paths ["src/cljsdev"]
                                       :figwheel true
                                       :compiler
                                       {:main ~(with-ns "dev")

--- a/src/cljsdev/org/broadinstitute/firecloud_ui/dev.cljs
+++ b/src/cljsdev/org/broadinstitute/firecloud_ui/dev.cljs
@@ -8,11 +8,7 @@
 ;; See https://github.com/binaryage/cljs-devtools
 ;; With these tools installed and "Enable custom formatters" checked in Chrome's devtools' settings,
 ;; Clojure data structures are much easier to inspect in the console and debugging windows.
-(defonce devtools-installed?
-  (do
-    (devtools/set-pref! :install-sanity-hints true)
-    (devtools/install!)
-    true))
+(devtools/install! [:formatters :hints])
 
 
 (main/render-application true)


### PR DESCRIPTION
ClojureScript supports preloads in 1.9. We're on 1.7. This change also adds the "hints" feature which is very helpful for "null" and "undefined" error messages.