### PR TITLE
Fix compiler warning due to circular dependency

### DIFF
--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -62,7 +62,6 @@
                     (if (map? style) style {}))
             :href (or href "javascript:;")
             :onClick (if disabled?
-                       ;; Have to fully qualify to avoid circular dependency
                        #(push-error-text
                          (if (string? disabled?) disabled? "This action is disabled."))
                        onClick)
@@ -89,7 +88,6 @@
                         :color (when disabled? (:text-light style/colors))}
                 :title (when disabled? (:disabled-text props))
                 :onClick (when disabled?
-                           ;; Have to fully qualify to avoid circular dependency
                            #(push-error-text
                              (or (:disabled-text props) "This option is not available.")))}
         [:input {:type "checkbox" :ref "check"

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -506,7 +506,7 @@
                                          (.focus (get-first)))))))))})
 
 (defn push-ok-cancel-modal [props]
-  (modal/push-modal (react/create-element OKCancelForm props)))
+  (modal/push-modal [OKCancelForm props]))
 
 (defn push-message [{:keys [header message]}]
   (push-ok-cancel-modal

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/components.cljs
@@ -5,10 +5,13 @@
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.codemirror :refer [CodeMirror]]
     [org.broadinstitute.firecloud-ui.common.icons :as icons]
+    [org.broadinstitute.firecloud-ui.common.modal :as modal]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
 
+
+(declare push-error-text)
 
 (react/defc Spinner
   {:render
@@ -60,7 +63,7 @@
             :href (or href "javascript:;")
             :onClick (if disabled?
                        ;; Have to fully qualify to avoid circular dependency
-                       #(org.broadinstitute.firecloud-ui.common.modal/push-error-text
+                       #(push-error-text
                          (if (string? disabled?) disabled? "This action is disabled."))
                        onClick)
             :onKeyDown (when (and onClick (not disabled?))
@@ -87,7 +90,7 @@
                 :title (when disabled? (:disabled-text props))
                 :onClick (when disabled?
                            ;; Have to fully qualify to avoid circular dependency
-                           #(org.broadinstitute.firecloud-ui.common.modal/push-error-text
+                           #(push-error-text
                              (or (:disabled-text props) "This option is not available.")))}
         [:input {:type "checkbox" :ref "check"
                  :defaultChecked (:initial-checked? props)
@@ -222,8 +225,7 @@
                       :border (when-not heavy? style/standard-line)
                       :borderRadius 5}
               :onClick (if disabled?
-                         ;; Have to fully qualify to avoid circular dependency
-                         #(org.broadinstitute.firecloud-ui.common.modal/push-error-text
+                         #(push-error-text
                            (if (string? disabled?) disabled? "This action is disabled."))
                          (:onClick props))}
         (icons/icon {:style {:padding "0 20px" :borderRight style/standard-line}} (:icon props))
@@ -449,3 +451,86 @@
    (fn [{:keys [refs this]}]
      (.addEventListener (@refs "filter-field") "search" #(when (= (.-value (.-currentTarget %)) "") (react/call :apply-filter this))))})
 
+
+(react/defc OKCancelForm
+  {:get-default-props
+   (fn []
+     {:show-cancel? true
+      :show-close? true})
+   :render
+   (fn [{:keys [props]}]
+     (let [{:keys [header content ok-button show-cancel? cancel-text show-close?]} props
+           cancel-text (or cancel-text "Cancel")]
+       [:div {}
+        [:div {:style {:borderBottom style/standard-line
+                       :padding "20px 48px 18px"
+                       :fontSize "137%" :fontWeight 400 :lineHeight 1}}
+         header
+         (when show-close? [XButton {:dismiss modal/pop-modal}])]
+        [:div {:style {:padding "22px 48px 40px" :backgroundColor (:background-light style/colors)}}
+         content
+         (when (or show-cancel? ok-button)
+           [:div {:style {:marginTop 40 :textAlign "center"}}
+            (when show-cancel?
+              [:a {:className "cancel"
+                   :style {:marginRight (when ok-button 27) :marginTop 2 :padding "0.5em"
+                           :display "inline-block"
+                           :fontSize "106%" :fontWeight 500 :textDecoration "none"
+                           :color (:button-primary style/colors)}
+                   :href "javascript:;"
+                   :onClick modal/pop-modal
+                   :onKeyDown (common/create-key-handler [:space :enter] modal/pop-modal)}
+               cancel-text])
+            (cond (string? ok-button) [Button {:text ok-button :ref "ok-button" :class-name "ok-button" :onClick modal/pop-modal}]
+              (fn? ok-button) [Button {:text "OK" :ref "ok-button" :class-name "ok-button" :onClick ok-button}]
+              (map? ok-button) [Button (merge {:ref "ok-button" :class-name "ok-button"} ok-button)]
+              :else ok-button)])]]))
+   :component-did-mount
+   (fn [{:keys [props refs]}]
+     (when-let [get-first (:get-first-element-dom-node props)]
+       (common/focus-and-select (get-first))
+       (when-let [get-last (or (:get-last-element-dom-node props)
+                               #(react/find-dom-node (@refs "ok-button")))]
+         (.addEventListener
+          (get-first) "keydown"
+          (common/create-key-handler [:tab] #(.-shiftKey %)
+                                     (fn [e] (.preventDefault e)
+                                       (when (:cycle-focus? props)
+                                         (.focus (get-last))))))
+         (.addEventListener
+          (get-last)
+          "keydown"
+          (common/create-key-handler [:tab] #(not (.-shiftKey %))
+                                     (fn [e] (.preventDefault e)
+                                       (when (:cycle-focus? props)
+                                         (.focus (get-first)))))))))})
+
+(defn push-ok-cancel-modal [props]
+  (modal/push-modal (react/create-element OKCancelForm props)))
+
+(defn push-message [{:keys [header message]}]
+  (push-ok-cancel-modal
+    {:header (or header "Message")
+     :content [:div {:style {:maxWidth 500}} message]
+     :show-cancel? false :ok-button "OK"}))
+
+(defn- push-error [content]
+  (push-ok-cancel-modal
+   {:header [:div {:style {:display "inline-flex" :alignItems "center"}}
+             (icons/icon {:style {:color (:exception-state style/colors)
+                                  :marginRight "0.5em"}} :error)
+             "Error"]
+    :content [:div {:style {:maxWidth "50vw"}} content]
+    :show-cancel? false :ok-button "OK"}))
+
+(defn push-error-text [error-text]
+  (push-error error-text))
+
+(defn push-error-response [error-response]
+  (push-error [ErrorViewer {:error error-response}]))
+
+(defn push-confirm [{:keys [header text on-confirm]}]
+  (push-ok-cancel-modal
+    {:header (or header "Confirm")
+     :content [:div {:style {:maxWidth 500}} text]
+     :ok-button on-confirm}))

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/gcs_file_preview.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/gcs_file_preview.cljs
@@ -2,7 +2,7 @@
   (:require
     [dmohs.react :as react]
     [org.broadinstitute.firecloud-ui.common :as common]
-    [org.broadinstitute.firecloud-ui.common.components :refer [Spinner]]
+    [org.broadinstitute.firecloud-ui.common.components :as comps :refer [Spinner]]
     [org.broadinstitute.firecloud-ui.common.modal :as modal]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
@@ -14,7 +14,7 @@
 (react/defc PreviewDialog
   {:render
    (fn [{:keys [props state]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "File Details"
        :content
        (let [{:keys [data error status]} (:response @state)

--- a/src/cljs/org/broadinstitute/firecloud_ui/common/modal.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/common/modal.cljs
@@ -2,7 +2,6 @@
   (:require
     [dmohs.react :as react]
     [org.broadinstitute.firecloud-ui.common :as common]
-    [org.broadinstitute.firecloud-ui.common.components :as comps]
     [org.broadinstitute.firecloud-ui.common.icons :as icons]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.utils :as u]
@@ -11,45 +10,12 @@
 
 (defonce ^:private instance (atom nil))
 
-
 (defn set-instance! [x]
   (reset! instance x))
 
 (defn push-modal [child]
   ;; Forces create-element so the caller can refer to refs in the dialog.
   (react/call :push-modal @instance (react/create-element child)))
-
-(declare OKCancelForm)
-(defn push-ok-cancel-modal [props]
-  (react/call :push-modal @instance (react/create-element OKCancelForm props)))
-
-
-(defn push-message [{:keys [header message]}]
-  (push-ok-cancel-modal
-    {:header (or header "Message")
-     :content [:div {:style {:maxWidth 500}} message]
-     :show-cancel? false :ok-button "OK"}))
-
-(defn- push-error [content]
-  (push-ok-cancel-modal
-   {:header [:div {:style {:display "inline-flex" :alignItems "center"}}
-             (icons/icon {:style {:color (:exception-state style/colors)
-                                  :marginRight "0.5em"}} :error)
-             "Error"]
-    :content [:div {:style {:maxWidth "50vw"}} content]
-    :show-cancel? false :ok-button "OK"}))
-
-(defn push-error-text [error-text]
-  (push-error error-text))
-
-(defn push-error-response [error-response]
-  (push-error [comps/ErrorViewer {:error error-response}]))
-
-(defn push-confirm [{:keys [header text on-confirm]}]
-  (push-ok-cancel-modal
-    {:header (or header "Confirm")
-     :content [:div {:style {:maxWidth 500}} text]
-     :ok-button on-confirm}))
 
 (defn pop-modal []
   (react/call :pop-modal @instance))
@@ -91,57 +57,3 @@
    :component-will-unmount
    (fn [{:keys [locals]}]
      (.removeEventListener js/window "keydown" (:keydown-handler @locals)))})
-
-
-(react/defc OKCancelForm
-  {:get-default-props
-   (fn []
-     {:show-cancel? true
-      :show-close? true})
-   :render
-   (fn [{:keys [props]}]
-     (let [{:keys [header content ok-button show-cancel? cancel-text show-close?]} props
-           cancel-text (or cancel-text "Cancel")]
-       [:div {}
-        [:div {:style {:borderBottom style/standard-line
-                       :padding "20px 48px 18px"
-                       :fontSize "137%" :fontWeight 400 :lineHeight 1}}
-         header
-         (when show-close? [comps/XButton {:dismiss pop-modal}])]
-        [:div {:style {:padding "22px 48px 40px" :backgroundColor (:background-light style/colors)}}
-         content
-         (when (or show-cancel? ok-button)
-           [:div {:style {:marginTop 40 :textAlign "center"}}
-            (when show-cancel?
-              [:a {:className "cancel"
-                   :style {:marginRight (when ok-button 27) :marginTop 2 :padding "0.5em"
-                           :display "inline-block"
-                           :fontSize "106%" :fontWeight 500 :textDecoration "none"
-                           :color (:button-primary style/colors)}
-                   :href "javascript:;"
-                   :onClick pop-modal
-                   :onKeyDown (common/create-key-handler [:space :enter] pop-modal)}
-               cancel-text])
-            (cond (string? ok-button) [comps/Button {:text ok-button :ref "ok-button" :class-name "ok-button" :onClick pop-modal}]
-                  (fn? ok-button) [comps/Button {:text "OK" :ref "ok-button" :class-name "ok-button" :onClick ok-button}]
-                  (map? ok-button) [comps/Button (merge {:ref "ok-button" :class-name "ok-button"} ok-button)]
-                  :else ok-button)])]]))
-   :component-did-mount
-   (fn [{:keys [props refs]}]
-     (when-let [get-first (:get-first-element-dom-node props)]
-       (common/focus-and-select (get-first))
-       (when-let [get-last (or (:get-last-element-dom-node props)
-                               #(react/find-dom-node (@refs "ok-button")))]
-         (.addEventListener
-          (get-first) "keydown"
-          (common/create-key-handler [:tab] #(.-shiftKey %)
-                                     (fn [e] (.preventDefault e)
-                                       (when (:cycle-focus? props)
-                                         (.focus (get-last))))))
-         (.addEventListener
-          (get-last)
-          "keydown"
-          (common/create-key-handler [:tab] #(not (.-shiftKey %))
-                                     (fn [e] (.preventDefault e)
-                                       (when (:cycle-focus? props)
-                                         (.focus (get-first)))))))))})

--- a/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/main.cljs
@@ -338,7 +338,7 @@
 
 
 (defn- show-system-status-dialog [maintenance-mode?]
-  (modal/push-ok-cancel-modal
+  (comps/push-ok-cancel-modal
     {:header (if maintenance-mode? "Maintenance Mode" "Server Unavailable")
      :show-cancel? false
      :content (if maintenance-mode?

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/billing/create_project.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/billing/create_project.cljs
@@ -13,7 +13,7 @@
 (react/defc CreateBillingProjectDialog
   {:render
    (fn [{:keys [state this]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "Create Billing Project"
        :content
        (react/create-element

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/billing/manage_project.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/billing/manage_project.cljs
@@ -15,7 +15,7 @@
 (react/defc AddUserDialog
   {:render
    (fn [{:keys [props state this refs]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header (str "Add user to " (:project-name props))
        :ok-button #(react/call :add-user this)
        :get-first-element-dom-node #(react/find-dom-node (@refs "email"))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/library/library_page.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/library/library_page.cljs
@@ -3,7 +3,6 @@
     [dmohs.react :as react]
     [org.broadinstitute.firecloud-ui.common :as common]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
-    [org.broadinstitute.firecloud-ui.common.modal :as modal]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
     [org.broadinstitute.firecloud-ui.common.style :as style]
     [org.broadinstitute.firecloud-ui.common.table :as table]
@@ -73,7 +72,7 @@
         :on-done (fn [{:keys [success?]}]
                    (if success?
                      (nav/navigate (:nav-context props) "workspaces" (common/row->workspace-id data))
-                     (modal/push-message {:header "Request Access"
+                     (comps/push-message {:header "Request Access"
                                           :message
                                             (if (= (config/tcga-namespace) (:namespace data))
                                              [:span {}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/create_method.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/create_method.cljs
@@ -15,7 +15,7 @@
 (react/defc CreateMethodDialog
   {:render
    (fn [{:keys [state refs this]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "Create New Method"
        :get-first-element-dom-node #(react/find-dom-node (@refs "namespace"))
        :get-last-element-dom-node #(react/find-dom-node (@refs "ok-button"))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/method_config_importer.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/method_config_importer.cljs
@@ -19,7 +19,7 @@
 (react/defc Redactor
   {:render
    (fn [{:keys [props state this]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "Confirm redaction"
        :content
        [:div {:style {:width 500}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/method_repo_page.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/method_repo_page.cljs
@@ -18,7 +18,7 @@
        {:allow-edit true
         :after-import
         (fn [{:keys [workspace-id config-id]}]
-          (modal/push-ok-cancel-modal
+          (comps/push-ok-cancel-modal
             {:header "Export successful"
              :content "Would you like to go to the edit page now?"
              :cancel-text "No, stay here"

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/methods_configs_acl.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/method_repo/methods_configs_acl.cljs
@@ -29,7 +29,7 @@
 (react/defc AgoraPermsEditor
   {:render
    (fn [{:keys [props refs state this]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header (str "Permissions for " (:title props))
        :content
        (react/create-element

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/analysis/track_selector.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/analysis/track_selector.cljs
@@ -118,7 +118,7 @@
      {:tracks (vec (:tracks props))})
    :render
    (fn [{:keys [props state]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "Select IGV Tracks"
        :ok-button {:text "Load"
                    :onClick

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/create.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/create.cljs
@@ -19,7 +19,7 @@
       :protected-option :not-loaded})
    :render
    (fn [{:keys [props state refs this]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "Create New Workspace"
        :ok-button {:text "Create Workspace" :onClick #(react/call :create-workspace this)}
        :get-first-element-dom-node #(@refs "project")

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/data/tab.cljs
@@ -25,7 +25,7 @@
                 :onClick #(swap! state update-in [:crumbs] (comp vec (partial take 1)))}]})
    :render
    (fn [{:keys [state props]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "Import Data"
        :show-cancel? false :ok-button {:text "Done" :onClick modal/pop-modal}
        :content

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/delete_config.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/delete_config.cljs
@@ -9,7 +9,7 @@
 (react/defc DeleteDialog
   {:render
    (fn [{:keys [props state]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "Confirm Delete"
        :content
        [:div {:style {:width 500}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/launch_analysis.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/launch_analysis.cljs
@@ -97,7 +97,7 @@
 (react/defc Form
   {:render
    (fn [{:keys [props state this]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "Launch Analysis"
        :content (render-form state props)
        :ok-button {:text "Launch" :disabled? (:disabled? props) :onClick #(react/call :launch this)}}])

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/method_config_editor.cljs
@@ -57,7 +57,7 @@
        :headers utils/content-type=json
        :on-done (fn [{:keys [success? get-parsed-response xhr]}]
                   (if-not success?
-                    (do (modal/push-error-text (str "Exception:\n" (.-statusText xhr)))
+                    (do (comps/push-error-text (str "Exception:\n" (.-statusText xhr)))
                         (swap! state dissoc :blocker))
                     (if (= name (config "name"))
                       (swap! state assoc :loaded-config (get-parsed-response false) :blocker nil)
@@ -69,7 +69,8 @@
                                     (swap! state dissoc :blocker)
                                     (if success?
                                       ((:on-rename props) name)
-                                      (modal/push-error-text (str "Exception:\n" (.-statusText xhr)))))}))))})))
+                                      (comps/push-error-text
+                                       (str "Exception:\n" (.-statusText xhr)))))}))))})))
 
 (react/defc MethodDetailsViewer
   {:get-fields

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/publish.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/publish.cljs
@@ -16,7 +16,7 @@
    (fn [{:keys [props state refs]}]
      (let [{:keys [workspace-id config]} props
            {:strs [namespace name]} config]
-       [modal/OKCancelForm
+       [comps/OKCancelForm
         {:header "Publish Method Configuration"
          :get-first-element-dom-node #(react/call :access-field (@refs "mcNamespace"))
          :content

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/method_configs/tab.cljs
@@ -43,7 +43,7 @@
                                         true "This workspace is locked."
                                         false)
                            :onClick #(modal/push-modal
-                                      [modal/OKCancelForm
+                                      [comps/OKCancelForm
                                        {:header "Import Method Configuration"
                                         :content
                                         [:div {:style {:backgroundColor "white" :padding "1ex" :width 1000}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/monitor/submission_details.cljs
@@ -115,7 +115,7 @@
              [comps/SidebarButton {:color :button-primary :style :light :margin :top
                                    :text "Abort" :icon :status-warning-triangle
                                    :onClick (fn [_]
-                                              (modal/push-confirm
+                                              (comps/push-confirm
                                                {:text "Are you sure you want to abort this submission?"
                                                 :on-confirm #(react/call :abort-submission this)}))}])
    :abort-submission (fn [{:keys [props state]}]
@@ -128,7 +128,8 @@
                                     (swap! state dissoc :aborting-submission?)
                                     (if success?
                                       ((:on-abort props))
-                                      (modal/push-error-text (str "Error in aborting the job : " status-text))))}))})
+                                      (comps/push-error-text
+                                       (str "Error in aborting the job : " status-text))))}))})
 
 
 (react/defc Page

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/acl_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/acl_editor.cljs
@@ -15,7 +15,7 @@
 
 
 (defn- render-acl-content [props state component]
-  [modal/OKCancelForm
+  [comps/OKCancelForm
    {:header
     (let [workspace-id (:workspace-id props)]
       (str "Permissions for " (:namespace workspace-id) "/" (:name workspace-id)))

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/attribute_editor.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/attribute_editor.cljs
@@ -123,7 +123,7 @@
                 [comps/Button {:text "Import Attributes..."
                                :style {:float "right" :marginTop -7}
                                :onClick #(modal/push-modal
-                                           [modal/OKCancelForm
+                                           [comps/OKCancelForm
                                             {:header "Import Attributes"
                                              :show-cancel? false :ok-button {:text "Done" :onClick modal/pop-modal}
                                              :content [:div {:style {:float "right" :width 720}}

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/publish.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/publish.cljs
@@ -2,7 +2,6 @@
   (:require
     [dmohs.react :as react]
     [org.broadinstitute.firecloud-ui.common.components :as comps]
-    [org.broadinstitute.firecloud-ui.common.modal :as modal]
     [org.broadinstitute.firecloud-ui.endpoints :as endpoints]
     [org.broadinstitute.firecloud-ui.utils :as utils]
     ))
@@ -25,10 +24,12 @@
                       :on-done (fn [{:keys [success? get-parsed-response]}]
                                  (swap! state dissoc :publishing?)
                                  (if success?
-                                   (do (modal/push-message {:header "Success!"
-                                                            :message "Successfully published to Library"})
+                                   (do (comps/push-message
+                                        {:header "Success!"
+                                         :message "Successfully published to Library"})
                                        ((:request-refresh props)))
-                                   (modal/push-error-response (get-parsed-response false))))}))}]])})
+                                   (comps/push-error-response
+                                    (get-parsed-response false))))}))}]])})
 
 (react/defc UnpublishButton
   {:render
@@ -46,7 +47,9 @@
                       :on-done (fn [{:keys [success? get-parsed-response]}]
                                  (swap! state dissoc :unpublishing?)
                                  (if success?
-                                   (do (modal/push-message {:header "Success!"
-                                                            :message "This dataset is no longer displayed in the Data Library catalog."})
+                                   (do (comps/push-message
+                                        {:header "Success!"
+                                         :message "This dataset is no longer displayed in the Data Library catalog."})
                                        ((:request-refresh props)))
-                                   (modal/push-error-response (get-parsed-response false))))}))}]])})
+                                   (comps/push-error-response
+                                    (get-parsed-response false))))}))}]])})

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/tab.cljs
@@ -22,7 +22,7 @@
 (react/defc DeleteDialog
   {:render
    (fn [{:keys [state this]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
        {:header "Confirm Delete"
         :content
         [:div {}
@@ -54,7 +54,7 @@
                 (swap! state dissoc :updating-attrs? :editing?)
                 (if success?
                   (request-refresh)
-                  (modal/push-error-response (get-parsed-response false))))}))
+                  (comps/push-error-response (get-parsed-response false))))}))
 
 
 (defn- render-sidebar [state refs this
@@ -106,7 +106,7 @@
                          (let [{:keys [success error]} (react/call :get-attributes (@refs "workspace-attribute-editor"))
                                new-description (react/call :get-text (@refs "description"))]
                            (if error
-                             (modal/push-error-text error)
+                             (comps/push-error-text error)
                              (save-attributes {:new-attributes (assoc success :description new-description)
                                                :state state
                                                :workspace-id workspace-id
@@ -269,8 +269,9 @@
         :on-done (fn [{:keys [success? status-text status-code]}]
                    (when-not success?
                      (if (and (= status-code 409) (not locked-now?))
-                       (modal/push-error-text "Could not lock workspace, one or more analyses are currently running")
-                       (modal/push-error-text (str "Error: " status-text))))
+                       (comps/push-error-text
+                        "Could not lock workspace, one or more analyses are currently running")
+                       (comps/push-error-text (str "Error: " status-text))))
                    (swap! state dissoc :locking?)
                    (react/call :refresh this))}))
    :component-did-mount

--- a/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/workspace_cloner.cljs
+++ b/src/cljs/org/broadinstitute/firecloud_ui/page/workspace/summary/workspace_cloner.cljs
@@ -16,7 +16,7 @@
      {:selected-project (first (:billing-projects props))})
    :render
    (fn [{:keys [props refs state this]}]
-     [modal/OKCancelForm
+     [comps/OKCancelForm
       {:header "Clone Workspace to:"
        :ok-button {:text "Clone" :onClick #(react/call :do-clone this)}
        :get-first-element-dom-node #(@refs "project")


### PR DESCRIPTION
Fixes `push-error-text` warning on clean builds. Now the circular dependency is more localized: `Button` depends on `OKCancelForm` which depends on `Button`. I don't love this, but I definitely like it better.