### PR TITLE
Add new key to config validation

### DIFF
--- a/src/cljs/main/broadfcui/config.cljs
+++ b/src/cljs/main/broadfcui/config.cljs
@@ -18,7 +18,8 @@
   (let [config-keys (set (keys config))
         required {"apiUrlRoot" :string "googleClientId" :string "tcgaNamespace" :string}
         optional {"cromwellVersion" :string "isDebug" :boolean "shibbolethUrlRoot" :string
-                  "submissionStatusRefresh" :integer "workflowCountWarningThreshold" :integer}
+                  "submissionStatusRefresh" :integer "userGuideUrl" :string
+                  "workflowCountWarningThreshold" :integer}
         all (merge required optional)
         missing-required (filter #(not (contains? config-keys %)) (keys required))
         extra (clojure.set/difference config-keys (set (keys all)))


### PR DESCRIPTION
This commit added a new config value that I didn't see when I was writing the test: https://github.com/broadinstitute/firecloud-ui/commit/3820cec8d6619e10c9f2dfc1fbc43dc4a752e3db