### PR TITLE
GAWB-1695: don't re-search when clicking outside library autocomplete

### DIFF
--- a/src/cljs/main/broadfcui/common/components.cljs
+++ b/src/cljs/main/broadfcui/common/components.cljs
@@ -489,9 +489,10 @@
          (doseq [item typeahead-events]
            (.bind (js/$ (@refs "field")) item on-select)))
        (.addEventListener (@refs "field") "search"
-                          #(when (and (empty? (.. % -currentTarget -value))
-                                      (:on-clear props))
-                             ((:on-clear props))))))})
+                          (fn []
+                            (.typeahead (js/$ (@refs "field")) "close")
+                            #(when (and (empty? (.. % -currentTarget -value)) (:on-clear props))
+                              ((:on-clear props)))))))})
 
 
 (react/defc AutocompleteFilter

--- a/src/cljs/main/broadfcui/page/library/library_page.cljs
+++ b/src/cljs/main/broadfcui/page/library/library_page.cljs
@@ -156,6 +156,7 @@
       [comps/AutocompleteFilter
        {:ref "text-filter"
         :on-filter (:on-filter props)
+        :typeahead-events ["typeahead:select"]
         :width "100%"
         :field-attributes {:defaultValue (:search-text props)
                            :placeholder "Search"}


### PR DESCRIPTION
Root cause of GAWB-1695 seems to have been the `typeahead:change` event.

I also added code to explicitly close the suggestions once the user performs a search. If you input some text and hit enter (without selecting a suggestion), the suggestion box will now disappear.

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
