### PR TITLE
Fix Sign-Out

### DIFF
--- a/src/cljs/main/broadfcui/common.cljs
+++ b/src/cljs/main/broadfcui/common.cljs
@@ -344,7 +344,8 @@
     :button-class "float-right"
     :button-style (merge {:fontSize "unset" :lineHeight "unset" :padding 0 :textAlign "center"}
                          button-style)
-    :close-on-click true
+    ;; TODO(dmohs): This prevents DropdownItem from receiving the click event.
+    ;; :close-on-click true
     :dropdown-class "bottom"
     :style {:boxShadow "0 3px 6px 0 rgba(0, 0, 0, 0.15)"
             :backgroundColor "#fff"


### PR DESCRIPTION
Our current implementation of close-on-click prevents click events which breaks sign-out. Disabling for now.
```
Ran 3 tests containing 16 assertions.
0 failures, 0 errors.
All tests passed.
```