### PR TITLE
When running tests, fail the build if it emits warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,14 +25,27 @@
                   :preloads [devtools.preload]
                   :external-config {:devtools/config {:features-to-install
                                                       [:formatters :hints]}}}}}}}
-             :deploy {:cljsbuild
-                      {:builds {:client {:compiler
-                                         {;; As of 10/29/15, advanced optimization triggers
-                                          ;; infinite recursion, which I was not able to figure
-                                          ;; out.
-                                          :optimizations :simple
-                                          :pretty-print false
-                                          :output-dir "build"}}}}}}
+             :deploy
+             {:cljsbuild
+              {:builds
+               {:client
+                {:compiler
+                 {;; As of 10/29/15, advanced optimization triggers
+                  ;; infinite recursion, which I was not able to figure
+                  ;; out.
+                  :optimizations :simple
+                  :pretty-print false
+                  :output-dir "build"}}}}}
+             :test-for-release
+             {:cljsbuild
+              {:builds
+               {:client
+                ;; http://jakemccrary.com/blog/2015/12/19/clojurescript-treat-warnings-as-errors/
+                {:warning-handlers [(fn [warning-type env extra]
+                                      (when-let [s (cljs.analyzer/error-message warning-type extra)]
+                                        (binding [*out* *err*]
+                                          (println "WARNING:" (cljs.analyzer/message env s)))
+                                        (System/exit 1)))]}}}}}
   :target-path "resources/public"
   :clean-targets ^{:protect false} [:target-path]
   :cljsbuild {:builds {:client {:source-paths ["src/cljs/main"]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,7 +26,7 @@ docker cp package.json fcuitests_clojure-node_1:/w
 
 compose_exec clojure-node npm install
 compose_exec clojure-node npm run webpack -- -p
-compose_exec clojure-node lein cljsbuild once
+compose_exec clojure-node lein with-profile +test-for-release cljsbuild once
 compose_exec clojure-node lein resource
 
 docker cp scripts/.phantom-run-tests.js fcuitests_clojure-node_1:/w/run-tests.js


### PR DESCRIPTION
No Jira ticket. Needs only regression, which runs on all snapshots.