### PR TITLE
GAWB-2338: Repopulate autocomplete engine on entity type change

### DIFF
--- a/src/cljs/main/broadfcui/common/components.cljs
+++ b/src/cljs/main/broadfcui/common/components.cljs
@@ -434,9 +434,9 @@
 (def Bloodhound (aget js/window "webpack-deps" "Bloodhound"))
 (def ^:private whitespace-tokenizer (aget Bloodhound "tokenizers" "whitespace"))
 
-(defn create-bloodhound-engine [{:keys [remote local]}]
-  (Bloodhound. (clj->js {:datumTokenizer whitespace-tokenizer
-                         :queryTokenizer whitespace-tokenizer
+(defn create-bloodhound-engine [{:keys [remote local datum-tokenizer query-tokenizer]}]
+  (Bloodhound. (clj->js {:datumTokenizer (or datum-tokenizer whitespace-tokenizer)
+                         :queryTokenizer (or query-tokenizer whitespace-tokenizer)
                          :remote remote
                          :local local})))
 
@@ -466,7 +466,7 @@
          (.typeahead (js/$ (@refs "field"))
                      (clj->js behavior)
                      (clj->js
-                      {:source (or engine (create-bloodhound-engine (select-keys props [:remote :local])))
+                      {:source (or engine (create-bloodhound-engine (select-keys props [:remote :local :datum-tokenizer :query-tokenizer])))
                        :display render-display
                        :templates {:empty (str "<div style='padding: 0.5em'>" empty-message "</div>")
                                    :suggestion render-suggestion}}))

--- a/src/cljs/main/broadfcui/page/workspace/method_configs/method_config_editor.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/method_configs/method_config_editor.cljs
@@ -26,13 +26,12 @@
 (defn- create-section [children]
   [:div {:style {:padding "1em 0 2em 0"}} children])
 
-(defn- refresh-autocomplete [props]
-  (let [{:keys [engine workspace-attributes entity-types selected-entity-type]} props
-        workspace-datums (map (partial str "workspace.") (map name (keys workspace-attributes)))
+(defn- refresh-autocomplete [{:keys [engine workspace-attributes entity-types selected-entity-type]}]
+  (let [workspace-datums (map (partial str "workspace.") (map name (keys workspace-attributes)))
         entity-datums (map (partial str "this.") (get-in entity-types [(keyword selected-entity-type) :attributeNames]))
         datums (concat entity-datums workspace-datums)]
     (.clear engine)
-    (.add (:engine props) (clj->js datums))))
+    (.add engine (clj->js datums))))
 
 (react/defc- MethodDetailsViewer
   {:get-fields

--- a/src/cljs/main/broadfcui/page/workspace/method_configs/method_config_editor.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/method_configs/method_config_editor.cljs
@@ -26,6 +26,14 @@
 (defn- create-section [children]
   [:div {:style {:padding "1em 0 2em 0"}} children])
 
+(defn- refresh-autocomplete [props]
+  (let [{:keys [engine workspace-attributes entity-types selected-entity-type]} props
+        workspace-datums (map (partial str "workspace.") (map name (keys workspace-attributes)))
+        entity-datums (map (partial str "this.") (get-in entity-types [(keyword selected-entity-type) :attributeNames]))
+        datums (concat entity-datums workspace-datums)]
+    ; (utils/cljslog (str "repopulating engine: " datums))
+    (.clear engine)
+    (.add (:engine props) (clj->js datums))))
 
 (react/defc- MethodDetailsViewer
   {:get-fields
@@ -113,10 +121,9 @@
      (swap! locals assoc
             :body-id (gensym "config")
             :engine (comps/create-bloodhound-engine
-                     {:local (->> (get-in props [:workspace :workspace :workspace-attributes])
-                                  keys
-                                  (map (comp (partial str "workspace.") name))
-                                  (concat ["this." "workspace."]))})))
+                     {:local []
+                      :datum-tokenizer (aget comps/Bloodhound "tokenizers" "nonword")
+                      :query-tokenizer (aget comps/Bloodhound "tokenizers" "nonword")})))
    :render
    (fn [{:keys [state this]}]
      (cond (every? @state [:loaded-config :methods]) (this :-render-display)
@@ -151,10 +158,11 @@
          (common/clear-both)]]))
    :-render-main
    (fn [{:keys [state this locals props]} locked?]
-     (let [{:keys [editing? loaded-config wdl-parse-error inputs-outputs methods]} @state
+     (let [{:keys [editing? loaded-config wdl-parse-error inputs-outputs methods entity-types]} @state
            config (:methodConfiguration loaded-config)
            {:keys [methodRepoMethod]} config
-           {:keys [body-id]} @locals]
+           {:keys [body-id engine]} @locals
+           workspace-attributes (get-in props [:workspace :workspace :workspace-attributes])]
        [:div {:style {:flex "1 1 auto"} :id body-id}
         (when-not editing?
           [:div {:style {:float "right"}}
@@ -189,7 +197,11 @@
            (style/create-identity-select {:ref "rootentitytype"
                                           :data-test-id (config/when-debug "edit-method-config-root-entity-type-select")
                                           :defaultValue (:rootEntityType config)
-                                          :style {:width 500}}
+                                          :style {:width 500}
+                                          :onChange #(refresh-autocomplete {:engine engine
+                                                                            :workspace-attributes workspace-attributes
+                                                                            :entity-types entity-types
+                                                                            :selected-entity-type (.. % -target -value)})}
                                          common/root-entity-types)
            [:div {:style {:padding "0.5em 0 1em 0"}} (:rootEntityType config)]))
         (create-section-header "Inputs")
@@ -251,12 +263,15 @@
         {:endpoint (endpoints/get-entity-types (:workspace-id props))
          :on-done (fn [{:keys [success? get-parsed-response status-text]}]
                     (if success?
-                      (.add (:engine @locals)
-                            (clj->js (->> (get-parsed-response)
-                                          vals
-                                          (map :attributeNames)
-                                          flatten
-                                          (map (partial str "this.")))))
+                      (let [loaded-config (:loaded-config @state)
+                            entity-types (get-parsed-response)
+                            workspace-attributes (get-in props [:workspace :workspace :workspace-attributes])
+                            selected-entity-type (get-in loaded-config [:methodConfiguration :rootEntityType])]
+                        (refresh-autocomplete {:engine (:engine @locals)
+                                               :workspace-attributes workspace-attributes
+                                               :entity-types entity-types
+                                               :selected-entity-type selected-entity-type})
+                        (swap! state assoc :entity-types entity-types))
                       ;; FIXME: :data-attribute-load-error is unused
                       (swap! state assoc :data-attribute-load-error status-text)))}))
      (let [{:keys [loaded-config inputs-outputs]} @state]

--- a/src/cljs/main/broadfcui/page/workspace/method_configs/method_config_editor.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/method_configs/method_config_editor.cljs
@@ -31,7 +31,6 @@
         workspace-datums (map (partial str "workspace.") (map name (keys workspace-attributes)))
         entity-datums (map (partial str "this.") (get-in entity-types [(keyword selected-entity-type) :attributeNames]))
         datums (concat entity-datums workspace-datums)]
-    ; (utils/cljslog (str "repopulating engine: " datums))
     (.clear engine)
     (.add (:engine props) (clj->js datums))))
 


### PR DESCRIPTION
Fix for https://broadinstitute.atlassian.net/browse/GAWB-2338

Changes in this PR:
* Dynamically repopulate the bloodhound engine when the entity type is changed
* Add the ability to provide custom tokenizers to the bloodhound component

---

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Product Owner** sign off
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Squash commits and merge to develop
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
