### PR TITLE
GAWB-2064: filter and sort workspaces when first loaded.

### DIFF
--- a/src/cljs/main/broadfcui/page/method_repo/method_config_importer.cljs
+++ b/src/cljs/main/broadfcui/page/method_repo/method_config_importer.cljs
@@ -21,7 +21,6 @@
    [broadfcui.page.method-repo.methods-configs-acl :as mca]
    [broadfcui.page.method-repo.synchronize :as mr-sync]
    [broadfcui.page.method-repo.redactor :refer [Redactor]]
-   [broadfcui.page.workspace.workspace-common :as ws-common]
    [broadfcui.utils :as utils]
    ))
 
@@ -86,7 +85,7 @@
   {:render
    (fn [{:keys [props state locals refs]}]
      (let [{:keys [workspace-id entity perform-copy]} props
-           {:keys [workspaces]} @state]
+           {:keys [selected-workspace]} @state]
        [:div {:style {:border style/standard-line
                       :backgroundColor (:background-light style/colors)
                       :borderRadius 8 :padding "1em" :marginTop "1em"}}
@@ -125,9 +124,9 @@
         (style/create-validation-error-message (:validation-error @state))
         [comps/ErrorViewer {:error (:server-error @state)}]
         [buttons/Button {:text (if workspace-id "Import" "Export")
-                         :disabled? (not (or workspace-id (:selected-workspace @state)))
+                         :disabled? (not (or workspace-id selected-workspace))
                          :data-test-id (if workspace-id "import-button" "export-button")
-                         :onClick #(perform-copy (:selected-workspace @state) refs)}]]))})
+                         :onClick #(perform-copy selected-workspace refs)}]]))})
 
 (defn- create-import-form [state props entity config? perform-copy]
   (let [{:keys [workspace-id on-delete]} props

--- a/src/cljs/main/broadfcui/page/method_repo/method_config_importer.cljs
+++ b/src/cljs/main/broadfcui/page/method_repo/method_config_importer.cljs
@@ -1,7 +1,6 @@
 (ns broadfcui.page.method-repo.method-config-importer
   (:require
    [dmohs.react :as react]
-   [clojure.string :as string]
    [broadfcui.common :as common]
    [broadfcui.common.components :as comps]
    [broadfcui.common.flex-utils :as flex]
@@ -83,7 +82,7 @@
 
 (react/defc ConfigExporter
   {:render
-   (fn [{:keys [props state locals refs]}]
+   (fn [{:keys [props state refs]}]
      (let [{:keys [workspace-id entity perform-copy]} props
            {:keys [selected-workspace]} @state]
        [:div {:style {:border style/standard-line


### PR DESCRIPTION
Addresses https://broadinstitute.atlassian.net/browse/GAWB-2064

---

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Product Owner** sign off
- [x] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [x] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
