### PR TITLE
GAWB-2759: fix double library searches

### DIFF
--- a/src/cljs/main/broadfcui/components/autosuggest.cljs
+++ b/src/cljs/main/broadfcui/components/autosuggest.cljs
@@ -37,11 +37,13 @@
    (fn [{:keys [locals props]}]
      (let [{:keys [on-submit]} props
            wrapped-on-submit (fn [e]
-                               (let [value (.. e -target -value)]
-                                 (when-not (empty? value)
-                                   (on-submit value))))
+                               (.preventDefault e)
+                               (.stopPropagation e)
+                               (on-submit (.. e -target -value)))
            on-clear (fn [e]
                       (when (empty? (.. e -target -value))
+                        (.preventDefault e)
+                        (.stopPropagation e)
                         (on-submit "")))]
        (swap! locals assoc
               :id (gensym "autosuggest")
@@ -93,7 +95,9 @@
                    {:value value
                     :onKeyDown (when-let [on-submit (:on-submit @locals)]
                                  (common/create-key-handler [:enter] on-submit))
-                    :onChange (fn [_ value]
+                    :onChange (fn [e value]
+                                (.preventDefault e)
+                                (.stopPropagation e)
                                 (let [value (.-newValue value)]
                                   (when caching?
                                     (swap! state assoc :value value))

--- a/src/cljs/main/broadfcui/components/autosuggest.cljs
+++ b/src/cljs/main/broadfcui/components/autosuggest.cljs
@@ -37,9 +37,12 @@
    (fn [{:keys [locals props]}]
      (let [{:keys [on-submit]} props
            wrapped-on-submit (fn [e]
-                               (on-submit (.. e -target -value)))
+                               (let [value (.. e -target -value)]
+                                 (when-not (empty? value)
+                                   (on-submit value))))
            on-clear (fn [e]
-                      (when (zero? (.. e -target -value -length)) (on-submit "")))]
+                      (when (empty? (.. e -target -value))
+                        (on-submit "")))]
        (swap! locals assoc
               :id (gensym "autosuggest")
               :on-clear (when on-submit on-clear)

--- a/src/cljs/main/broadfcui/components/autosuggest.cljs
+++ b/src/cljs/main/broadfcui/components/autosuggest.cljs
@@ -37,7 +37,9 @@
    (fn [{:keys [locals props]}]
      (let [{:keys [on-submit]} props
            wrapped-on-submit (fn [e]
-                               (on-submit (.. e -target -value)))
+                               (let [value (.. e -target -value)]
+                                 (when-not (empty? value)
+                                   (on-submit value))))
            on-clear (fn [e]
                       (when (empty? (.. e -target -value))
                         (on-submit "")))]

--- a/src/cljs/main/broadfcui/page/library/library_page.cljs
+++ b/src/cljs/main/broadfcui/page/library/library_page.cljs
@@ -261,8 +261,6 @@
      :renderSuggestion (fn [suggestion]
                          (react/create-element (highlight-suggestion (js->clj suggestion))))
      :highlightFirstSuggestion false
-     :onSuggestionSelected (fn [_ suggestion]
-                             (on-filter (.-suggestionValue suggestion)))
      :on-change on-input
      :on-submit on-filter
      :theme {:input {:width "100%" :marginBottom 0}


### PR DESCRIPTION
This involves a bit of a change to the Autocomplete component, so we need to check for regressions.

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Product Owner** sign off
- [x] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [x] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
