### PR TITLE
GAWB-2845: Give more space to "Attribute" column in method config table

### DIFF
--- a/src/cljs/main/broadfcui/common/method/config_io.cljs
+++ b/src/cljs/main/broadfcui/common/method/config_io.cljs
@@ -69,13 +69,13 @@
                       :behavior {:filterable? false :reorderable-columns? false :allow-no-sort? true
                                  :sortable-columns? (not editing?)}
                       :columns
-                      (concat [{:header "Task" :initial-width 150
+                      (concat [{:header "Task" :initial-width 180
                                 :sort-by (comp (partial mapv string/lower-case) (juxt :task :variable))
                                 :sort-initial :asc
                                 :as-text :task
                                 :render (fn [{:keys [task]}]
                                           [:div {:style (clip table-style/table-cell-plank-left)} task])}
-                               {:header "Variable" :initial-width 180
+                               {:header "Variable" :initial-width 220
                                 :as-text (fn [{:keys [variable optional?]}]
                                            (str variable (when optional? " (optional)")))
                                 :sort-by (comp string/lower-case :text)
@@ -96,7 +96,7 @@
                                                         table-style/table-cell-plank-right))}
                                    (or type "unknown")])}]
                               (when values
-                                [{:header "Attribute" :initial-width 400
+                                [{:header "Attribute" :initial-width 360
                                   :as-text :value
                                   :sort-by :text
                                   :render

--- a/src/cljs/main/broadfcui/common/method/config_io.cljs
+++ b/src/cljs/main/broadfcui/common/method/config_io.cljs
@@ -69,7 +69,7 @@
                       :behavior {:filterable? false :reorderable-columns? false :allow-no-sort? true
                                  :sortable-columns? (not editing?)}
                       :columns
-                      (concat [{:header "Task" :initial-width 180
+                      (concat [{:header "Task" :initial-width 150
                                 :sort-by (comp (partial mapv string/lower-case) (juxt :task :variable))
                                 :sort-initial :asc
                                 :as-text :task
@@ -84,7 +84,7 @@
                                                                 (merge table-style/table-cell-plank-middle
                                                                        table-style/table-cell-optional)
                                                                 table-style/table-cell-plank-middle))} variable])}
-                               {:header "Type" :initial-width 120
+                               {:header "Type" :initial-width 110
                                 :sort-by :type
                                 :as-text (fn [{:keys [type optional?]}]
                                            (str type (when optional? " (optional)")))
@@ -96,7 +96,7 @@
                                                         table-style/table-cell-plank-right))}
                                    (or type "unknown")])}]
                               (when values
-                                [{:header "Attribute" :initial-width 200
+                                [{:header "Attribute" :initial-width 400
                                   :as-text :value
                                   :sort-by :text
                                   :render
@@ -121,7 +121,7 @@
                                           [:span {:style {:color (:text-lighter style/colors)}}
                                            (if optional? "Optional" "Required")])])])}])
                               (when invalid-values
-                                [{:header "Message" :initial-width 400
+                                [{:header "Message" :initial-width 200
                                   :as-text :error-message :sort-by :text
                                   :render
                                   (fn [{:keys [optional? error-message]}]


### PR DESCRIPTION
"Some users didn't know they could resize it" -- well then tell them they can.

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Product Owner** sign off
- [x] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [x] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [x] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
