### PR TITLE
GAWB-3073: Refresh workspace when workspace-id changes

### DIFF
--- a/src/cljs/main/broadfcui/page/workspace/details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/details.cljs
@@ -159,7 +159,7 @@
      (this :-refresh-workspace))
    :component-will-receive-props
    (fn [{:keys [props next-props this after-update]}]
-     (when (not= (:tab-name props) (:tab-name next-props))
+     (when (some identity (utils/changes [:tab-name :workspace-id] props next-props))
        (after-update this :-refresh-workspace)))
    :-refresh-workspace
    (fn [{:keys [props state]}]


### PR DESCRIPTION
This was fallout from my previous effort to eliminate double refreshes in workspace tabs.

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Product Owner** sign off
- [x] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [x] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [x] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
