### PR TITLE
address CVE-2018-7651 identified by github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -492,7 +492,7 @@
         "move-concurrently": "1.0.1",
         "promise-inflight": "1.0.1",
         "rimraf": "2.6.2",
-        "ssri": "5.1.0",
+        "ssri": "5.2.2",
         "unique-filename": "1.1.0",
         "y18n": "3.2.1"
       }
@@ -5251,9 +5251,9 @@
       }
     },
     "ssri": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.1.0.tgz",
-      "integrity": "sha512-TevC8fgxQKTfQ1nWtM9GNzr3q5rrHNntG9CDMH1k3QhSZI6Kb+NbjLRs8oPFZa2Hgo7zoekL+UTvoEk7tsbjQg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.2.tgz",
+      "integrity": "sha512-hm46mN8YSzjGuJtVocXPjwo0yTRXobXqYuK/tV6gr557/tRck4yWXKPRW8OxyJgRvcL3QgX+5ng/kMHBMco7KA==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"


### PR DESCRIPTION
Github's security scanner proactively identified CVE-2018-7651. This upgrades the vulnerable dependency.