### PR TITLE
make sure workflows pass

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/metadata/DataSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/metadata/DataSpec.scala
@@ -107,6 +107,7 @@ class DataSpec extends FreeSpec with WebBrowserSpec
           val methodConfigDetailsPage = new WorkspaceMethodConfigDetailsPage(billingProject, workspaceName, SimpleMethodConfig.configNamespace, methodConfigName).open
           val submissionTab = methodConfigDetailsPage.launchAnalysis(SimpleMethodConfig.rootEntityType, TestData.SingleParticipant.entityId, "", false)
           submissionTab.waitUntilSubmissionCompletes()
+          assert(submissionTab.verifyWorkflowSucceeded())
           workspaceDataTab.open
           //there is at least one filter bug - possibly two that was breaking the tests
           //1) Not sure if bug or not: filter from launch analysis modal is still present when data tab revisited
@@ -144,6 +145,7 @@ class DataSpec extends FreeSpec with WebBrowserSpec
           val methodConfigDetailsPage = new WorkspaceMethodConfigDetailsPage(billingProject, workspaceName, SimpleMethodConfig.configNamespace, methodConfigName).open
           val submissionTab = methodConfigDetailsPage.launchAnalysis(SimpleMethodConfig.rootEntityType, TestData.SingleParticipant.entityId, "", false)
           submissionTab.waitUntilSubmissionCompletes()
+          assert(submissionTab.verifyWorkflowSucceeded())
           val workspaceDataTab = new WorkspaceDataPage(billingProject, workspaceName).open
           workspaceDataTab.dataTable.clearFilter()
           workspaceDataTab.dataTable.readColumnHeaders shouldEqual List("participant_id", "test2", "output")
@@ -181,6 +183,7 @@ class DataSpec extends FreeSpec with WebBrowserSpec
           val methodConfigDetailsPage = new WorkspaceMethodConfigDetailsPage(billingProject, workspaceName, SimpleMethodConfig.configNamespace, methodConfigName).open
           val submissionTab = methodConfigDetailsPage.launchAnalysis(SimpleMethodConfig.rootEntityType, TestData.SingleParticipant.entityId, "", false)
           submissionTab.waitUntilSubmissionCompletes()
+          assert(submissionTab.verifyWorkflowSucceeded())
           val workspaceDataTab = new WorkspaceDataPage(billingProject, workspaceName).open
           workspaceDataTab.dataTable.clearFilter()
           workspaceDataTab.dataTable.readColumnHeaders shouldEqual List("participant_id", "test1", "output")
@@ -219,9 +222,7 @@ class DataSpec extends FreeSpec with WebBrowserSpec
           val methodConfigDetailsPage = new WorkspaceMethodConfigDetailsPage(billingProject, workspaceName, SimpleMethodConfig.configNamespace, methodConfigName).open
           val submissionTab = methodConfigDetailsPage.launchAnalysis(SimpleMethodConfig.rootEntityType, TestData.SingleParticipant.entityId, "", false)
           submissionTab.waitUntilSubmissionCompletes()
-          if (submissionTab.readWorkflowStatus() != "Succeeded") {
-            submissionTab.readStatusMessage() shouldEqual ""
-          }
+          assert(submissionTab.verifyWorkflowSucceeded())
           val workspaceDataTab = new WorkspaceDataPage(billingProject, workspaceName).open
           workspaceDataTab.dataTable.clearFilter()
           workspaceDataTab.dataTable.readColumnHeaders shouldEqual List("participant_id", "test3", "output")


### PR DESCRIPTION
dataspec tests were not asserting that test workflows actually succeed which leads to confusing failures

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [ ] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
