### PR TITLE
stop an infinite ajax loop

### DIFF
--- a/src/cljs/main/broadfcui/page/workspace/data/entity_viewer.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/data/entity_viewer.cljs
@@ -35,8 +35,8 @@
    (fn [{:keys [this props]}]
      (this :-handle-props props))
    :component-will-receive-props
-   (fn [{:keys [this next-props]}]
-     (this :-handle-props next-props))
+   (fn [{:keys [this props next-props]}]
+     (this :-handle-props next-props props))
    :render
    (fn [{:keys [props state this]}]
      (let [{:keys [update-parent-state]} props
@@ -123,9 +123,10 @@
                                     :render :for-render}])}
                 :paginator :none}]]))
    :-handle-props
-   (fn [{:keys [this]} props]
-     (let [{:keys [entity-type entity-name]} props]
-       (this :-update-and-load entity-type entity-name)))
+   (fn [{:keys [this]} next-props props]
+     (when (not (and (= (:entity-type props) (:entity-type next-props)) (= (:entity-name props) (:entity-name next-props))))
+       (let [{:keys [entity-type entity-name]} next-props]
+         (this :-update-and-load entity-type entity-name))))
    :-update-and-load
    (fn [{:keys [state props]} item-type item-name]
      (let [update-viewer-state (fn [& args]

--- a/src/cljs/main/broadfcui/page/workspace/data/entity_viewer.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/data/entity_viewer.cljs
@@ -124,7 +124,7 @@
                 :paginator :none}]]))
    :-handle-props
    (fn [{:keys [this]} next-props props]
-     (when (not (and (= (:entity-type props) (:entity-type next-props)) (= (:entity-name props) (:entity-name next-props))))
+     (when (utils/any-change [:entity-type :entity-name] props next-props)
        (let [{:keys [entity-type entity-name]} next-props]
          (this :-update-and-load entity-type entity-name))))
    :-update-and-load


### PR DESCRIPTION
this is https://app.zenhub.com/workspace/o/databiosphere/firecloud-app/issues/29.

To reproduce:
1. open dev tools and start watching ajax requests
2. navigate into the data table for a workspace
3. click on an entity (e.g. a sample set) to view its contents
4. infinite ajax DOS.

#1255 introduced a new `update-health` callback for ajax functions. This callback tickled the `EntityViewer`'s `component-will-receive-props` method, which triggered an ajax request, which triggered `component-will-receive-props`, which caused a loop.

in this PR, I only trigger an ajax request from `EntityViewer` if the entity being viewed has actually changed.