### PR TITLE
in EntityViewer component, ensure strings

### DIFF
--- a/src/cljs/main/broadfcui/page/workspace/data/entity_viewer.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/data/entity_viewer.cljs
@@ -117,7 +117,7 @@
                                                :for-render [FilePreviewLink (assoc parsed
                                                                               :attributes {:style {:display "inline"}}
                                                                               :link-label v)]}
-                                              {:for-sort (string/lower-case v)
+                                              {:for-sort (string/lower-case (str v))
                                                :for-render v})))
                                     :sort-by :for-sort
                                     :render :for-render}])}


### PR DESCRIPTION
https://github.com/DataBiosphere/firecloud-app/issues/58 ... I was able to replicate this issue and have a fix.

The problem occurs when a workspace entity contains a numeric attribute. In this situation, the attribute renders correctly in the main table, but if you click on the entity's id to view its details in the right-side viewer, we tried to apply `toLowerCase` to a number. This resulted in a JavaScript error that caused the entire page to go blank.

To reproduce:
1. Create a workspace
2. Copy some entities from elsewhere or import from a TSV.
3. Manually update your entities to have a numeric attribute, using the "Update entity in a workspace" API (which is lacking doc on what payload it expects)
4. Reload the page to get your new attributes. Note that they render correctly in the main table.
5. Click on an entity's id to view its details

Expected: details render correctly.
Actual: page goes boom.

_If you want to test this in the dev env, I have a workspace I can share with you that will allow you to skip steps 1-4!_

If you follow the case logic in the code, you can see we have one case for `map?`, another case for `attribute-list?`, a third case for `dos-or-gcs-uri?`, and then everything else - including numbers - hit the `(string/lower-case v)` statement. That statement throws an error for numbers. So I'm making sure everything is a string at that point.

