### PR TITLE
in entity importer, pin the add icon to always be visible

### DIFF
--- a/src/cljs/main/broadfcui/page/workspace/data/entity_selector.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/data/entity_selector.cljs
@@ -70,7 +70,8 @@
                             {:data (data source?)
                              :body {:empty-message ((if source? :left-empty-text :right-empty-text) props)
                                     :style table-style/table-heavy
-                                    :columns (columns source?)}
+                                    :columns (columns source?)
+                                    :behavior {:fixed-column-count 1}}
                              :toolbar
                              {:style {:flexWrap "wrap"}
                               :get-items


### PR DESCRIPTION
This is for issue DataBiosphere/firecloud-app#37.

Pretty simple fix - make sure the "+" column is fixed and cannot be removed. See other examples of `fixed-column-count` on tables, such as in the Monitor tab of a workspace.
