### PR TITLE
 show call cache at the submission level. Hide some call details for subworkflows

### DIFF
--- a/src/cljs/main/broadfcui/page/workspace/monitor/common.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/common.cljs
@@ -94,7 +94,10 @@
     :else (do (utils/log "Unknown submission status: " wf-statuses)
               (render-unknown-icon))))
 
-(defn icon-for-project-status [project-status]
+(defn icon-for-submission [sub-status wf-statuses]
+  (if (= "Done" sub-status)
+    (icon-for-sub-status wf-statuses)
+    (icon-for-wf-status sub-status)))(defn icon-for-project-status [project-status]
   (cond
     (= project-status "Error") (render-failure-icon)
     (= project-status "Ready") (render-success-icon)

--- a/src/cljs/main/broadfcui/page/workspace/monitor/common.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/common.cljs
@@ -110,6 +110,15 @@
     :else (do (utils/log "Unknown call status: " status)
               (render-unknown-icon))))
 
+(defn icons-for-call-statuses [statuses]
+  [:span {}
+    (when (some #(contains? call-success-statuses %) statuses)
+     (render-success-icon))
+    (when (some #(contains? call-failure-statuses %) statuses)
+     (render-failure-icon))
+    (when (some #(contains? call-running-statuses %) statuses)
+      (render-running-icon))])
+
 (defn format-call-cache [cache-hit]
   (if cache-hit "Hit" "Miss"))
 

--- a/src/cljs/main/broadfcui/page/workspace/monitor/common.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/common.cljs
@@ -110,10 +110,6 @@
     :else (do (utils/log "Unknown call status: " status)
               (render-unknown-icon))))
 
-
-(defn call-cache-result [cache-status]
-  (if (= cache-status "ReadAndWriteCache") "Enabled" "Disabled"))
-
 (defn format-call-cache [cache-hit]
   (if cache-hit "Hit" "Miss"))
 

--- a/src/cljs/main/broadfcui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/submission_details.cljs
@@ -173,48 +173,51 @@
                            (this :load-details))
                :workspace-id (:workspace-id props)
                :submission-id (:submissionId submission)}])]
-          [:div {:style {:float "left"}}
-           (style/create-section-header "Method Configuration")
-           (style/create-paragraph
-            [:div {}
-             [:div {:style {:fontWeight 200 :display "inline-block" :width 90}} "Namespace:"]
-             [:span {:style {:fontWeight 500}} (:methodConfigurationNamespace submission)]]
-            [:div {}
-             [:div {:style {:fontWeight 200 :display "inline-block" :width 90}} "Name:"]
-             [:span {:style {:fontWeight 500}} (:methodConfigurationName submission)]])
-           (style/create-section-header "Submission Entity")
-           (style/create-paragraph
-            [:div {}
-             [:div {:style {:fontWeight 200 :display "inline-block" :width 90}} "Type:"]
-             [:span {:style {:fontWeight 500}} (get-in submission [:submissionEntity :entityType])]]
-            [:div {}
-             [:div {:style {:fontWeight 200 :display "inline-block" :width 90}} "Name:"]
-             [:span {:style {:fontWeight 500}} (get-in submission [:submissionEntity :entityName])]])
-           (style/create-section-header "Call Caching")
-           (style/create-paragraph
-            [:div {}
-             [:span {:style {:fontWeight 500}} (if (:useCallCache submission) "Enabled" "Disabled")]])]
-          [:div {:style {:float "right"}}
-           (style/create-section-header "Submitted by")
-           (style/create-paragraph
-            [:div {} (:submitter submission)]
-            [:div {} (common/format-date (:submissionDate submission)) " ("
-             (duration/fuzzy-time-from-now-ms (.parse js/Date (:submissionDate submission)) true) ")"])
-           (style/create-section-header "Submission ID")
-           (style/create-paragraph
-            (links/create-external
-              {:data-test-id "submission-id"
-               :href (str
-                      moncommon/google-storage-context
-                      (:bucketName props) "/" (:submissionId submission) "/")}
-              (:submissionId submission)))
-           (style/create-section-header [:div {} "Total Run Cost"
-                                         (dropdown/render-info-box
-                                          {:text "Costs may take up to one day to populate."})])
-           (style/create-paragraph
-            ((fn [cost]
-               (if (or (= 0 cost) (nil? cost)) "Not Available" (common/format-price cost)))
-             (:cost submission)))]
+          [:div {:style {:float "right" :width "calc(100% - 330px)"}} 
+           [:div {:style {:float "left" :width "33.33%"}}
+            (style/create-section-header "Method Configuration")
+            (style/create-paragraph
+             [:div {}
+              [:div {:style {:fontWeight 200 :display "inline-block" :width 90}} "Namespace:"]
+              [:span {:style {:fontWeight 500}} (:methodConfigurationNamespace submission)]]
+             [:div {}
+              [:div {:style {:fontWeight 200 :display "inline-block" :width 90}} "Name:"]
+              [:span {:style {:fontWeight 500}} (:methodConfigurationName submission)]])
+            (style/create-section-header "Submission Entity")
+            (style/create-paragraph
+             [:div {}
+              [:div {:style {:fontWeight 200 :display "inline-block" :width 90}} "Type:"]
+              [:span {:style {:fontWeight 500}} (get-in submission [:submissionEntity :entityType])]]
+             [:div {}
+              [:div {:style {:fontWeight 200 :display "inline-block" :width 90}} "Name:"]
+              [:span {:style {:fontWeight 500}} (get-in submission [:submissionEntity :entityName])]])]
+           [:div {:style {:float "left" :width "33.33%"}}
+            (style/create-section-header "Submitted by")
+            (style/create-paragraph
+             [:div {} (:submitter submission)]
+             [:div {} (common/format-date (:submissionDate submission)) " ("
+              (duration/fuzzy-time-from-now-ms (.parse js/Date (:submissionDate submission)) true) ")"])
+            (style/create-section-header "Submission ID")
+            (style/create-paragraph
+             (links/create-external
+               {:data-test-id "submission-id"
+                :href (str
+                       moncommon/google-storage-context
+                       (:bucketName props) "/" (:submissionId submission) "/")}
+               (:submissionId submission)))]
+           [:div {:style {:float "left" :width "33.33%"}}
+            (style/create-section-header [:div {} "Total Run Cost"
+                                          (dropdown/render-info-box
+                                           {:text "Costs may take up to one day to populate."})])
+            (style/create-paragraph
+             [:div {} ((fn [cost]
+                (if (or (= 0 cost) (nil? cost)) "Not Available" (common/format-price cost)))
+              (:cost submission))]
+             [:br {}]) ;; extra br to align section headers across columns
+            (style/create-section-header "Call Caching")
+            (style/create-paragraph
+             [:div {}
+              [:span {:style {:fontWeight 500}} (if (:useCallCache submission) "Enabled" "Disabled")]])]]
           (common/clear-both)
           [:h2 {} "Workflows:"]
           [WorkflowsTable {:workflows (:workflows submission)

--- a/src/cljs/main/broadfcui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/submission_details.cljs
@@ -113,7 +113,7 @@
                                                    (:submission-id props))}
                               {:text workflowName}]}]]
         (workflow-details/render
-         (merge (select-keys props [:workspace-id :submission-id :bucketName])
+         (merge (select-keys props [:workspace-id :submission-id :use-call-cache :bucketName])
                 {:workflow-id workflowId
                  :submission (:submission props)
                  :workflow-name workflowName}))]))})
@@ -189,7 +189,11 @@
              [:span {:style {:fontWeight 500}} (get-in submission [:submissionEntity :entityType])]]
             [:div {}
              [:div {:style {:fontWeight 200 :display "inline-block" :width 90}} "Name:"]
-             [:span {:style {:fontWeight 500}} (get-in submission [:submissionEntity :entityName])]])]
+             [:span {:style {:fontWeight 500}} (get-in submission [:submissionEntity :entityName])]])
+           (style/create-section-header "Call Caching")
+           (style/create-paragraph
+            [:div {}
+             [:span {:style {:fontWeight 500}} (if (:useCallCache submission) "Enabled" "Disabled")]])]
           [:div {:style {:float "right"}}
            (style/create-section-header "Submitted by")
            (style/create-paragraph
@@ -218,6 +222,7 @@
                            :submission submission
                            :bucketName (:bucketName props)
                            :submission-id (:submissionId submission)
+                           :use-call-cache (:useCallCache submission)
                            :workflow-id (:workflow-id props)}]])))
    :load-details
    (fn [{:keys [props state]}]

--- a/src/cljs/main/broadfcui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/submission_details.cljs
@@ -214,10 +214,14 @@
                 (if (or (= 0 cost) (nil? cost)) "Not Available" (common/format-price cost)))
               (:cost submission))]
              [:br {}]) ;; extra br to align section headers across columns
-            (style/create-section-header "Call Caching")
+            (style/create-section-header [:div {} "Call Caching"
+                                          (dropdown/render-info-box
+                                           {:text (if (:useCallCache submission)
+                                             "Call caching was enabled for this submission by its submitter. Review individual
+                                                workflow calls below to see if they are cache hits or misses."
+                                             "Call caching was disabled for this submission by its submitter.")})])
             (style/create-paragraph
-             [:div {}
-              [:span {:style {:fontWeight 500}} (if (:useCallCache submission) "Enabled" "Disabled")]])]]
+             [:div {} (if (:useCallCache submission) "Enabled" "Disabled")])]]
           (common/clear-both)
           [:h2 {} "Workflows:"]
           [WorkflowsTable {:workflows (:workflows submission)

--- a/src/cljs/main/broadfcui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/tab.cljs
@@ -40,10 +40,7 @@
        :as-text (fn [submission] (.stringify js/JSON (clj->js (:workflowStatuses submission))))
        :render (fn [submission]
                  [:div {:style {:height table-style/table-icon-size}}
-                  (case (:status submission)
-                    "Done" (moncommon/icon-for-sub-status (:workflowStatuses submission))
-                    "Aborted" moncommon/render-failure-icon
-                    nil)
+                  (moncommon/icon-for-submission (:status submission) (:workflowStatuses submission))
                   (:status submission)])}
       {:header "Method Configuration" :initial-width 300
        :column-data (juxt :methodConfigurationNamespace :methodConfigurationName)

--- a/src/cljs/main/broadfcui/page/workspace/monitor/tab.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/tab.cljs
@@ -35,7 +35,9 @@
        :render #(links/create-internal {:data-test-id (str "submission-" %)
                                         :href (nav/get-link :workspace-submission workspace-id %)}
                   "View")}
-      {:header "Status" :as-text :status :sort-by :text
+      {:header "Status"
+       :sort-by (fn [submission] (:status submission))
+       :as-text (fn [submission] (.stringify js/JSON (clj->js (:workflowStatuses submission))))
        :render (fn [submission]
                  [:div {:style {:height table-style/table-icon-size}}
                   (case (:status submission)

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -236,11 +236,13 @@
       :subworkflow-expanded {}})
    :render
    (fn [{:keys [props state]}]
-     (let [call-path-components (conj (:gcs-path-prefix props) (str "call-" (call-name (:label props))))]
+     (let [call-path-components (conj (:gcs-path-prefix props) (str "call-" (call-name (:label props))))
+           all-call-statuses (set (map #(get % "executionStatus") (:data props)))]
        [:div {:style {:marginTop "1em"}}
         (when (:show-operation-dialog? @state)
           [OperationDialog (:operation-dialog-props @state)])
         [:div {:style {:display "inline-block" :marginRight "1em"}}
+         (moncommon/icons-for-call-statuses all-call-statuses)
          (links/create-external {:href (render-gcs-path call-path-components)} (:label props))]
         (links/create-internal {:onClick #(swap! state update :expanded not)}
                                (if (:expanded @state) "Hide" "Show"))

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -293,10 +293,10 @@
                 (create-field "Ended" (moncommon/render-date (data "end")))
                 [IODetail {:label "Inputs" :data (data "inputs") :call-detail? true}]
                 [IODetail {:label "Outputs" :data (data "outputs") :call-detail? true}]
-                (when (data "stdout")
-                  (create-field "stdout" (display-value (data "stdout") (last (string/split (data "stdout") #"/")))))
-                (when (data "stderr")
-                  (create-field "stderr" (display-value (data "stderr") (last (string/split (data "stderr") #"/")))))
+                (when-let [stdout (data "stdout")]
+                  (create-field "stdout" (display-value stdout (last (string/split stdout #"/")))))
+                (when-let [stderr (data "stderr")]
+                  (create-field "stderr" (display-value stderr (last (string/split stderr #"/")))))
                 (backend-logs data)
                 (when-let [failures (data "failures")]
                   [Failures {:data failures}])]])

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -284,17 +284,17 @@
                                (data "jobId")])
                 (let [status (data "executionStatus")]
                   (create-field "Status" (moncommon/icon-for-call-status status) status))
-                (when (and (:use-call-cache props) (not (data "subWorkflowId")))
+                (when (and (:use-call-cache props) (some? (get (data "callCaching") "hit")))
                   (create-field "Cache Result" (moncommon/format-call-cache (get (data "callCaching") "hit"))))
                 (create-field "Started" (moncommon/render-date (data "start")))
                 ;(utils/cljslog data)
                 (create-field "Ended" (moncommon/render-date (data "end")))
                 [IODetail {:label "Inputs" :data (data "inputs") :call-detail? true}]
                 [IODetail {:label "Outputs" :data (data "outputs") :call-detail? true}]
-                (when (not (data "subWorkflowId"))
-                  (do
-                    (create-field "stdout" (display-value (data "stdout") (last (string/split (data "stdout") #"/"))))
-                    (create-field "stderr" (display-value (data "stderr") (last (string/split (data "stderr") #"/"))))))
+                (when (data "stdout")
+                  (create-field "stdout" (display-value (data "stdout") (last (string/split (data "stdout") #"/")))))
+                (when (data "stdout")
+                  (create-field "stderr" (display-value (data "stderr") (last (string/split (data "stderr") #"/")))))
                 (backend-logs data)
                 (when-let [failures (data "failures")]
                   [Failures {:data failures}])]])

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -309,7 +309,7 @@
                    :backgroundColor (:background-light style/colors)}}
      (create-field "Workflow ID" (links/create-external {:href (render-gcs-path workflow-path-components)} (workflow "id")))
      (let [status (workflow "status")]
-       (create-field "Status" (moncommon/icon-for-wf-status status)))
+       (create-field "Status" (moncommon/icon-for-wf-status status) status))
      (create-field "Total Run Cost" (moncommon/render-cost workflow-cost))
      (when-let [submission (workflow "submission")]
        (create-field "Submitted" (moncommon/render-date submission)))

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -293,7 +293,7 @@
                 [IODetail {:label "Outputs" :data (data "outputs") :call-detail? true}]
                 (when (data "stdout")
                   (create-field "stdout" (display-value (data "stdout") (last (string/split (data "stdout") #"/")))))
-                (when (data "stdout")
+                (when (data "stderr")
                   (create-field "stderr" (display-value (data "stderr") (last (string/split (data "stderr") #"/")))))
                 (backend-logs data)
                 (when-let [failures (data "failures")]

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -185,7 +185,7 @@
 
 ;; Subworkflows contain a lot of information that is redundant to what can be seen from the Calls
 ;; Only show new information
-(defn- render-subworkflow-detail [workflow raw-data workflow-name submission-id workspace-id gcs-path-prefix]
+(defn- render-subworkflow-detail [workflow raw-data workflow-name submission-id use-call-cache workspace-id gcs-path-prefix]
   (let [inputs (ffirst (workflow "calls"))
         input-names (string/split inputs ".")
         workflow-name-for-path (first input-names)
@@ -193,8 +193,6 @@
     [:div {:style {:padding "1em" :border style/standard-line :borderRadius 4
                    :backgroundColor (:background-light style/colors)}}
      (create-field "Subworkflow ID" (links/create-external {:href (render-gcs-path subworkflow-path-components)} (workflow "id")))
-     (let [call-cache-status (-> (workflow "calls") vals first first (get "callCaching") (get "effectiveCallCachingMode"))]
-       (create-field "Call Caching" (moncommon/call-cache-result call-cache-status)))
      (when (seq (workflow "calls"))
        [WorkflowTiming {:label "Workflow Timing" :data raw-data :workflow-name workflow-name}])
      (when-let [failures (workflow "failures")]
@@ -202,7 +200,7 @@
      (when (seq (workflow "calls"))
        [:div {:style {:marginTop "1em" :fontWeight 500}} "Calls:"])
      (for [[call data] (workflow "calls")]
-       [CallDetail {:label call :data data :submission-id submission-id :workflowId (workflow "id")
+       [CallDetail {:label call :data data :submission-id submission-id :use-call-cache use-call-cache :workflowId (workflow "id")
                     :workspace-id workspace-id :gcs-path-prefix subworkflow-path-components}])]))
 
 (react/defc- SubworkflowDetails
@@ -217,7 +215,7 @@
           (style/create-server-error-message (:response server-response))
           :else
           (render-subworkflow-detail (:response server-response) (:raw-response server-response)
-                                     (:workflow-name props) (:submission-id props)
+                                     (:workflow-name props) (:submission-id props) (:use-call-cache props)
                                      (:workspace-id props) (:gcs-path-prefix props))))])
       :component-did-mount
       (fn [{:keys [props state]}]
@@ -265,7 +263,7 @@
                       (let [subworkflow-path-prefix (if (>= (data "shardIndex") 0)
                                                       (conj call-path-components (str "shard-" index))
                                                       call-path-components)]
-                        [SubworkflowDetails (merge (select-keys props [:workspace-id :submission-id :workflow-name])
+                        [SubworkflowDetails (merge (select-keys props [:workspace-id :submission-id :use-call-cache :workflow-name])
                                                    {:workflow-id subWorkflowId
                                                     :gcs-path-prefix subworkflow-path-prefix})])]
                      ;; click to show subworkflow details and add it to the :subworkflow-expanded map in @state
@@ -286,21 +284,23 @@
                                (data "jobId")])
                 (let [status (data "executionStatus")]
                   (create-field "Status" (moncommon/icon-for-call-status status) status))
-                (when (= (get-in data ["callCaching" "effectiveCallCachingMode"]) "ReadAndWriteCache")
+                (when (and (:use-call-cache props) (not (data "subWorkflowId")))
                   (create-field "Cache Result" (moncommon/format-call-cache (get (data "callCaching") "hit"))))
                 (create-field "Started" (moncommon/render-date (data "start")))
                 ;(utils/cljslog data)
                 (create-field "Ended" (moncommon/render-date (data "end")))
                 [IODetail {:label "Inputs" :data (data "inputs") :call-detail? true}]
                 [IODetail {:label "Outputs" :data (data "outputs") :call-detail? true}]
-                (create-field "stdout" (display-value (data "stdout") (last (string/split (data "stdout") #"/"))))
-                (create-field "stderr" (display-value (data "stderr") (last (string/split (data "stderr") #"/"))))
+                (when (not (data "subWorkflowId"))
+                  (do
+                    (create-field "stdout" (display-value (data "stdout") (last (string/split (data "stdout") #"/"))))
+                    (create-field "stderr" (display-value (data "stderr") (last (string/split (data "stderr") #"/"))))))
                 (backend-logs data)
                 (when-let [failures (data "failures")]
                   [Failures {:data failures}])]])
             (:data props)))]))})
 
-(defn- render-workflow-detail [workflow raw-data workflow-name submission-id workflow-cost workspace-id gcs-path-prefix]
+(defn- render-workflow-detail [workflow raw-data workflow-name submission-id use-call-cache workflow-cost workspace-id gcs-path-prefix]
   (let [inputs (ffirst (workflow "calls"))
         input-names (string/split inputs ".")
         workflow-name-for-path (first input-names)
@@ -311,8 +311,6 @@
      (let [status (workflow "status")]
        (create-field "Status" (moncommon/icon-for-wf-status status)))
      (create-field "Total Run Cost" (moncommon/render-cost workflow-cost))
-     (let [call-cache-status (-> (workflow "calls") vals first first (get "callCaching") (get "effectiveCallCachingMode"))]
-       (create-field "Call Caching" (moncommon/call-cache-result call-cache-status)))
      (when-let [submission (workflow "submission")]
        (create-field "Submitted" (moncommon/render-date submission)))
      (when-let [start (workflow "start")]
@@ -330,7 +328,7 @@
      (when (seq (workflow "calls"))
        [:div {:style {:marginTop "1em" :fontWeight 500}} "Calls:"])
      (for [[call data] (workflow "calls")]
-       [CallDetail {:label call :data data :submission-id submission-id :workflowId (workflow "id")
+       [CallDetail {:label call :data data :submission-id submission-id :use-call-cache use-call-cache :workflowId (workflow "id")
                     :workspace-id workspace-id :gcs-path-prefix workflow-path-components}])]))
 
 (react/defc- WorkflowDetails
@@ -353,7 +351,7 @@
          ;; top-level workflows use workspace-bucket-name/submission-id
          (let [workflow-path-prefix [(:bucketName props) (:submission-id props)]]
            (render-workflow-detail (:response metadata-response) (:raw-response metadata-response)
-                                   (:workflow-name props) (:submission-id props)
+                                   (:workflow-name props) (:submission-id props) (:use-call-cache props)
                                    (:response cost-response) (:workspace-id props)
                                    workflow-path-prefix)))))
    :component-did-mount
@@ -378,5 +376,5 @@
 
 
 (defn render [props]
-  (assert (every? #(contains? props %) #{:workspace-id :submission-id :workflow-id}))
+  (assert (every? #(contains? props %) #{:workspace-id :submission-id :use-call-cache :workflow-id}))
   [WorkflowDetails props])


### PR DESCRIPTION
## Dear Reviewer:

you probably want to 1) review each commit individually, and 2) ignore whitespace when viewing the diff.

The first commit:
* displays the user's choice of enable/disable call cache at the submission level, beside other submission details
* removes the call-cache display from individual workflows
* hides stdout/stderr lines for calls that are subworkflows, since those values don't exist at this level (you have to query the subworkflow directly)

The second commit:
* changes the submission details from a two-column display to three columns. This includes an indentation change, moving some lines of code around, and causes huge diffs in github.

Third commit:
* a more generic way to show/hide some call fields - hide if the field is nil.

More commits:
* bonus feature! Display the workflow's status text next to its icon (GAWB-2098)
* bonus feature! Hover text over each submission's status in the main monitor tab shows summary of workflow statuses. (kinda GAWB-2355)
* bonus feature! Display a summary of call statuses next to unexpanded calls (GAWB-873, GAWB-223)
* bonus feature! More consistent icons for submission status on the monitor tab. Previously, many rows had no icon: Submitted, Aborting. This also eliminates a JS error in console.

## Submission details

### Before
![submission-details-before](https://user-images.githubusercontent.com/6041577/41432214-501982ae-6fe3-11e8-9222-040b80ab3308.png)

### After
![submission-details-after](https://user-images.githubusercontent.com/6041577/41432220-5367ceac-6fe3-11e8-81fc-0644e81a1430.png)

## Workflow details

### Before
![workflow-details-before](https://user-images.githubusercontent.com/6041577/41432239-5c176f76-6fe3-11e8-95b8-bb790281b8c6.png)
_(the root issue this ticket is about is that the call cache values displayed here are incorrect. I'm solving it by moving the call cache value to the submission level.)_

### After
![workflow-details-after](https://user-images.githubusercontent.com/6041577/41432242-5eecc0de-6fe3-11e8-8091-5c6e03c1e49b.png)


- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [ ] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
