### PR TITLE
Workaround to successfully request GPAlloced billing project

### DIFF
--- a/automation/logback-test.xml
+++ b/automation/logback-test.xml
@@ -8,13 +8,13 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d{HH:mm:ss} [%-30.30(%thread)] %highlight(%-5level) [%-25.25logger{25}:%method] - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss} [%-31.31(%thread)] %highlight(%-5level) [%-25.25logger{25}:%method] - %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-30.30(%thread)] %-5level [%-25.25logger{25}:%method] - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-31.31(%thread)] %-5level [%-25.25logger{25}:%method] - %msg%n</pattern>
             <outputPatternAsHeader>true</outputPatternAsHeader>
         </encoder>
         <file>${dir.name}/test-reports/TEST-${test.name}.log</file>

--- a/automation/logback-test.xml
+++ b/automation/logback-test.xml
@@ -8,13 +8,13 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%-70(%d{HH:mm:ss} [%thread]) %highlight(%-5level) %-50([%-30.30logger{30}:%method]) - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss} [%-30.30(%thread)] %highlight(%-5level) [%-25.25logger{25}:%method] - %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%-70(%d{yyyy-MM-dd HH:mm:ss} [%thread]) %-5level %-50([%-30.30logger{30}:%method]) - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-30.30(%thread)] %-5level [%-25.25logger{25}:%method] - %msg%n</pattern>
             <outputPatternAsHeader>true</outputPatternAsHeader>
         </encoder>
         <file>${dir.name}/test-reports/TEST-${test.name}.log</file>

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.11-b58e59d-SNAP"
+  val serviceTestV = "0.11-03be1e8-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.11-7d9d627-SNAP"
+  val serviceTestV = "0.11-283b01f-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.10-61981d5"
+  val serviceTestV = "0.11-039d218-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.11-283b01f-SNAP"
+  val serviceTestV = "0.11-8cb4f65-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.11-e72e15c-SNAP"
+  val serviceTestV = "0.11-b58e59d-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.11-8cb4f65-SNAP"
+  val serviceTestV = "0.11-e72e15c-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.11-039d218-SNAP"
+  val serviceTestV = "0.11-7d9d627-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -23,8 +23,7 @@ object Settings {
     "-feature",
     "-encoding", "utf8",
     "-target:jvm-1.8",
-    "-Xmax-classfile-name", "100",
-    "-Xfatal-warnings"
+    "-Xmax-classfile-name", "100"
   )
 
   // test parameters explanation:

--- a/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/library/PublishSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/library/PublishSpec.scala
@@ -10,17 +10,19 @@ import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.UserPool
 import org.broadinstitute.dsde.workbench.fixture.{BillingFixtures, WorkspaceFixtures}
 import org.broadinstitute.dsde.workbench.service.test.{CleanUp, WebBrowserSpec}
+import org.broadinstitute.dsde.workbench.service.util.Retry
 import org.broadinstitute.dsde.workbench.service.util.Retry.retry
 import org.scalatest._
+import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
 
 import scala.concurrent.duration.DurationLong
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 
-class PublishSpec extends FreeSpec with WebBrowserSpec with UserFixtures with WorkspaceFixtures with BillingFixtures with CleanUp with Matchers {
+class PublishSpec extends FreeSpec with WebBrowserSpec with UserFixtures with WorkspaceFixtures with BillingFixtures with CleanUp with Matchers with Eventually {
 
-  implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+  //implicit val ec: ExecutionContextExecutor = ExecutionContext.global
   implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(500, Millis)))
 
   val autocompleteTextQueryPrefix: String = "cance"  // partial string of "cancer" to test autocomplete
@@ -110,7 +112,7 @@ class PublishSpec extends FreeSpec with WebBrowserSpec with UserFixtures with Wo
                   // Micro-sleep to keep the test from failing (let Elasticsearch catch up?)
                   //            Thread sleep 500
 
-                  retry[Boolean](100.milliseconds, 1.minute)({
+                  Retry.retry[Boolean](100.milliseconds, 1.minute)({
                     val libraryPage = wspage.goToDataLibrary()
                     libraryPage.doSearch(wsName)
                     if (libraryPage.hasDataset(wsName))

--- a/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/previewmodal/PreviewSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/previewmodal/PreviewSpec.scala
@@ -5,7 +5,7 @@ import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.UserPool
 import org.broadinstitute.dsde.workbench.fixture.{BillingFixtures, MethodFixtures, WorkspaceFixtures}
 import org.broadinstitute.dsde.workbench.service.test.WebBrowserSpec
-import org.broadinstitute.dsde.workbench.service.util.Retry.retry
+import org.broadinstitute.dsde.workbench.service.util.Retry
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FreeSpec, Matchers, ParallelTestExecution}
@@ -141,7 +141,7 @@ class PreviewSpec extends FreeSpec with ParallelTestExecution with WebBrowserSpe
             eventually { previewModal.getObject shouldBe s"$gObject" }
             // preview pane is only created if there's something to preview so
             // give it .1 sec
-            retry[Boolean](100.milliseconds, 1.minute)({
+            Retry.retry[Boolean](100.milliseconds, 1.minute)({
               val previewPane = previewModal.findInner("preview-pane")
               // avoids org.openqa.selenium.NoSuchElementException thrown from previewPane.webElement call
               val allElem = previewPane.findAllElements

--- a/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/user/FreeTrialSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/user/FreeTrialSpec.scala
@@ -7,7 +7,9 @@ import org.broadinstitute.dsde.firecloud.fixture.UserFixtures
 import org.broadinstitute.dsde.firecloud.page.workspaces.WorkspaceListPage
 import org.broadinstitute.dsde.workbench.auth.{AuthToken, TrialBillingAccountAuthToken}
 import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
+import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.service.Orchestration.billing.BillingProjectRole
 import org.broadinstitute.dsde.workbench.service._
 import org.broadinstitute.dsde.workbench.service.test.{CleanUp, WebBrowserSpec}
 import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
@@ -19,7 +21,7 @@ import scala.util.Try
   * Tests for new user registration scenarios.
   */
 class FreeTrialSpec extends FreeSpec with BeforeAndAfterEach with Matchers with WebBrowserSpec
-  with UserFixtures with CleanUp with LazyLogging {
+  with UserFixtures with BillingFixtures with CleanUp with LazyLogging {
 
   val adminUser: Credentials = UserPool.chooseAdmin
   val campaignManager: Credentials = UserPool.chooseCampaignManager
@@ -36,13 +38,6 @@ class FreeTrialSpec extends FreeSpec with BeforeAndAfterEach with Matchers with 
     userAuthToken = testUser.makeAuthToken()
     subjectId = Orchestration.profile.getUser()(userAuthToken)("userId").toString
     Try(trialKVPKeys foreach { k => Thurloe.keyValuePairs.delete(subjectId, k)})
-  }
-
-  private def setUpEnabledUserAndProject(user: Credentials): Unit = {
-    implicit val authToken: AuthToken = campaignManager.makeAuthToken()
-    api.trial.createTrialProjects(1)
-    logger.info(s"Attempting to enable user [${user.email}] as campaign manager [${campaignManager.email}]")
-    api.trial.enableUser(user.email)
   }
 
   private def registerCleanUpForDeleteTrialState(): Unit = {
@@ -64,63 +59,65 @@ class FreeTrialSpec extends FreeSpec with BeforeAndAfterEach with Matchers with 
     }
 
     "Enabled" - {
-      "should be able to see the free trial banner, enroll and get terminated" ignore {
-        setUpEnabledUserAndProject(testUser)
+      "should be able to see the free trial banner, enroll and get terminated" in {
         val trialAuthToken = TrialBillingAccountAuthToken()
-        api.trial.reportTrialProjects().foreach { x =>
-          register cleanUp Try(Rawls.admin.deleteBillingProject(x.name, UserInfo(OAuth2BearerToken(trialAuthToken.value),
-            WorkbenchUserId("0"), WorkbenchEmail("doesnt@matter.com"), 3600))(UserPool.chooseAdmin.makeAuthToken())).recover {
-              case ex: RestException => logger.warn(s"RestException occurred in Rawls.admin.deleteBillingProject(${x.name})", ex)
+        withCleanBillingProject(campaignManager, ownerEmails = List(trialAuthToken.buildCredential.getServiceAccountId)) { project =>
+          register cleanUp api.trial.scratchTrialProject(project)
+          registerCleanUpForDeleteTrialState()
+
+          api.trial.adoptTrialProject(project)
+          api.trial.enableUser(testUser.email)
+          removeMembersFromBillingProject(project, List(campaignManager.email), BillingProjectRole.Owner)(trialAuthToken)
+          withWebDriver { implicit driver =>
+            withSignIn(testUser) { _ =>
+              await ready new WorkspaceListPage()
+              val bannerTitleElement = Label(TestId("trial-banner-title"))
+              bannerTitleElement.isVisible shouldBe true
+              bannerTitleElement.getText shouldBe "Welcome to FireCloud!"
+
+              val bannerButton = await ready Button(TestId("trial-banner-button"))
+              bannerButton.doClick()
+
+              val reviewButton = await ready Button(TestId("review-terms-of-service"))
+              reviewButton.doClick()
+
+              val agreeTermsCheckbox = await ready Checkbox(TestId("agree-terms"))
+              agreeTermsCheckbox.ensureChecked()
+
+              val agreeCloudTermsCheckbox = await ready Checkbox(TestId("agree-cloud-terms"))
+              agreeCloudTermsCheckbox.ensureChecked()
+
+              val acceptButton = await ready Button(TestId("accept-terms-of-service"))
+              acceptButton.doClick()
+
+              await condition bannerButton.getState == "ready"
+              bannerTitleElement.getText shouldBe "Access Free Credits"
+            }
           }
+
+          // Verify that the user has been added to the corresponding billing project
+          val billingProject = Thurloe.keyValuePairs.getAll(subjectId).get("trialBillingProjectName")
+          assert(billingProject.nonEmpty, s"No trial billing project was allocated for the user ${testUser.email}.")
+
+          val userBillingProjects = api.profile.getUserBillingProjects()(userAuthToken)
+          assert(userBillingProjects.nonEmpty, s"The trial user ${testUser.email} has no billing projects.")
+
+          val userHasTheRightBillingProject: Boolean = userBillingProjects.exists(_.values.toList.contains(billingProject.get))
+          assert(userHasTheRightBillingProject)
+
+          // Verify that the user's project is removed from the account upon termination
+          val billingAccountUponEnrollment = Google.billing.getBillingProjectAccount(billingProject.get)(trialAuthToken)
+          assert(billingAccountUponEnrollment.nonEmpty, s"The user's project is not associated with a billing account.")
+
+          api.trial.terminateUser(testUser.email)
+
+          val billingAccountUponTermination = Google.billing.getBillingProjectAccount(billingProject.get)(trialAuthToken)
+          val errMsg = "The trial user's billing project should have been removed from the billing account."
+          assert(billingAccountUponTermination.isEmpty, errMsg)
+
+          // need to re-add a project owner in order for cleanup to succeed
+          addMembersToBillingProject(project, List(campaignManager.email), BillingProjectRole.Owner)(trialAuthToken)
         }
-        withWebDriver { implicit driver =>
-          withSignIn(testUser) { _ =>
-            await ready new WorkspaceListPage()
-            val bannerTitleElement = Label(TestId("trial-banner-title"))
-            bannerTitleElement.isVisible shouldBe true
-            bannerTitleElement.getText shouldBe "Welcome to FireCloud!"
-
-            val bannerButton = await ready Button(TestId("trial-banner-button"))
-            bannerButton.doClick()
-
-            val reviewButton = await ready Button(TestId("review-terms-of-service"))
-            reviewButton.doClick()
-
-            val agreeTermsCheckbox = await ready Checkbox(TestId("agree-terms"))
-            agreeTermsCheckbox.ensureChecked()
-
-            val agreeCloudTermsCheckbox = await ready Checkbox(TestId("agree-cloud-terms"))
-            agreeCloudTermsCheckbox.ensureChecked()
-
-            val acceptButton = await ready Button(TestId("accept-terms-of-service"))
-            acceptButton.doClick()
-
-            await condition bannerButton.getState == "ready"
-            bannerTitleElement.getText shouldBe "Access Free Credits"
-          }
-        }
-
-        // Verify that the user has been added to the corresponding billing project
-        val billingProject = Thurloe.keyValuePairs.getAll(subjectId).get("trialBillingProjectName")
-        assert(billingProject.nonEmpty, s"No trial billing project was allocated for the user ${testUser.email}.")
-
-        val userBillingProjects = api.profile.getUserBillingProjects()(userAuthToken)
-        assert(userBillingProjects.nonEmpty, s"The trial user ${testUser.email} has no billing projects.")
-
-        val userHasTheRightBillingProject: Boolean = userBillingProjects.exists(_.values.toList.contains(billingProject.get))
-        assert(userHasTheRightBillingProject)
-
-        // Verify that the user's project is removed from the account upon termination
-        val billingAccountUponEnrollment = Google.billing.getBillingProjectAccount(billingProject.get)(trialAuthToken)
-        assert(billingAccountUponEnrollment.nonEmpty, s"The user's project is not associated with a billing account.")
-
-        api.trial.terminateUser(testUser.email)
-
-        val billingAccountUponTermination = Google.billing.getBillingProjectAccount(billingProject.get)(trialAuthToken)
-        val errMsg = "The trial user's billing project should have been removed from the billing account."
-        assert(billingAccountUponTermination.isEmpty, errMsg)
-
-        registerCleanUpForDeleteTrialState()
       }
     }
 
@@ -152,8 +149,8 @@ class FreeTrialSpec extends FreeSpec with BeforeAndAfterEach with Matchers with 
         }
       }
     }
-   
-   "Finalized" - {
+
+    "Finalized" - {
       "should not see the free trial banner" in {
         registerCleanUpForDeleteTrialState()
         Thurloe.keyValuePairs.set(subjectId, "trialState", "Finalized")


### PR DESCRIPTION
Don't fail automated test without retry if an exception was thrown when claiming a GPAlloc billing project.  
e.g.
```
[info]   org.broadinstitute.dsde.workbench.service.RestException: {"source":"rawls","causes":[],"exceptionClass":"org.broadinstitute.dsde.rawls.RawlsException","stackTrace":[{"className":"org.broadinstitute.dsde.rawls.dataaccess.slick.RawlsBillingProjectComponent$rawlsBillingProjectQuery$","methodName":"$anonfun$create$1","fileName":"RawlsBillingProjectComponent.scala","lineNumber":49},{"className":"slick.basic.BasicBackend$DatabaseDef","methodName":"$anonfun$runInContext$1","fileName":"BasicBackend.scala","lineNumber":147},{"className":"scala.concurrent.Future","methodName":"$anonfun$flatMap$1","fileName":"Future.scala","lineNumber":302},{"className":"scala.concurrent.impl.Promise","methodName":"$anonfun$transformWith$1","fileName":"Promise.scala","lineNumber":37},{"className":"scala.concurrent.impl.CallbackRunnable","methodName":"run","fileName":"Promise.scala","lineNumber":60},{"className":"scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask","methodName":"exec","fileName":"ExecutionContextImpl.scala","lineNumber":140},{"className":"java.util.concurrent.ForkJoinTask","methodName":"doExec","fileName":"ForkJoinTask.java","lineNumber":289},{"className":"java.util.concurrent.ForkJoinPool$WorkQueue","methodName":"pollAndExecAll","fileName":"ForkJoinPool.java","lineNumber":1021},{"className":"java.util.concurrent.ForkJoinPool$WorkQueue","methodName":"execLocalTasks","fileName":"ForkJoinPool.java","lineNumber":1046},{"className":"java.util.concurrent.ForkJoinPool$WorkQueue","methodName":"runTask","fileName":"ForkJoinPool.java","lineNumber":1058},{"className":"java.util.concurrent.ForkJoinPool","methodName":"runWorker","fileName":"ForkJoinPool.java","lineNumber":1692},{"className":"java.util.concurrent.ForkJoinWorkerThread","methodName":"run","fileName":"ForkJoinWorkerThread.java","lineNumber":157}],"message":"Cannot create billing project [gpalloc-qa-master-2z4jdey] in database because it already exists"}
```

https://broadinstitute.atlassian.net/browse/GAWB-3637


- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [ ] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
