### PR TITLE
Remove storage scopes from UI

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.12-4234c49-SNAP"
+  val serviceTestV = "0.12-f94667c-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.12-560c0ce-SNAP"
+  val serviceTestV = "0.11-e923c03"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.12-f96655f-SNAP"
+  val serviceTestV = "0.12-da66918"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.12-f94667c-SNAP"
+  val serviceTestV = "0.12-1434363-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.12-1434363-SNAP"
+  val serviceTestV = "0.12-f96655f-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.11-e923c03"
+  val serviceTestV = "0.12-4234c49-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 object Dependencies {
   val jacksonV = "2.9.0"
 
-  val serviceTestV = "0.11-0fed732"
+  val serviceTestV = "0.12-560c0ce-SNAP"
 
   val workbenchExclusions = Seq(
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_$scalaBinaryVersion"),

--- a/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/billing/BillingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/billing/BillingSpec.scala
@@ -64,7 +64,7 @@ class BillingSpec extends FreeSpec with WebBrowserSpec with UserFixtures with Cl
            * have seen break in the past that relied on using a brand new billing project).
            */
           withWebDriver { implicit driver =>
-            withSignIn(user) { listPage =>
+            withScopedSignIn(user, AuthTokenScopes.billingScopes) { listPage =>
               //BEGIN: Test creating billing project in UI
               val billingPage = new BillingManagementPage().open
               val billingProjectName = createNewBillingProject(user, billingPage)

--- a/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/billing/BillingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/billing/BillingSpec.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.fixture.{TestData, UserFixtures, WebDriverIdLogging}
 import org.broadinstitute.dsde.firecloud.page.billing.BillingManagementPage
 import org.broadinstitute.dsde.firecloud.page.workspaces.methodconfigs.WorkspaceMethodConfigDetailsPage
-import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.auth.{AuthToken, AuthTokenScopes}
 import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
 import org.broadinstitute.dsde.workbench.fixture._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
@@ -54,7 +54,7 @@ class BillingSpec extends FreeSpec with WebBrowserSpec with UserFixtures with Cl
          */
         "should be able add a new user, create a workspace, and run a method, change billing account" in {
           val user = UserPool.chooseProjectOwner
-          implicit val authToken: AuthToken = user.makeAuthToken()
+          implicit val authToken: AuthToken = user.makeAuthToken(AuthTokenScopes.billingScopes)
           val secondUser = UserPool.chooseStudent.email
           val testData = TestData()
 
@@ -131,7 +131,7 @@ class BillingSpec extends FreeSpec with WebBrowserSpec with UserFixtures with Cl
     log.info(s"Creating billing project: $billingProjectName")
 
     billingPage.createBillingProject(billingProjectName, FireCloudConfig.Projects.billingAccount)
-    register cleanUp Rawls.admin.deleteBillingProject(billingProjectName, UserInfo(OAuth2BearerToken(user.makeAuthToken().value), WorkbenchUserId("0"), WorkbenchEmail(user.email), 3600))(UserPool.chooseAdmin.makeAuthToken())
+    register cleanUp Rawls.admin.deleteBillingProject(billingProjectName, UserInfo(OAuth2BearerToken(user.makeAuthToken(AuthTokenScopes.billingScopes).value), WorkbenchUserId("0"), WorkbenchEmail(user.email), 3600))(UserPool.chooseAdmin.makeAuthToken(AuthTokenScopes.billingScopes))
 
     val statusOption = billingPage.waitForCreateDone(billingProjectName)
 

--- a/src/cljs/main/broadfcui/auth.cljs
+++ b/src/cljs/main/broadfcui/auth.cljs
@@ -2,6 +2,7 @@
   (:require
    [dmohs.react :as react]
    [clojure.string :as string]
+   [broadfcui.common :refer [login-scopes]]
    [broadfcui.common.links :as links]
    [broadfcui.common.style :as style]
    [broadfcui.components.spinner :refer [spinner]]
@@ -13,8 +14,6 @@
    [broadfcui.utils.user :as user]
    ))
 
-(def login-scopes ["email" "profile"])
-(def storage-scopes (conj login-scopes "https://www.googleapis.com/auth/devstorage.read_only"))
 
 (react/defc GoogleAuthLibLoader
   {:render

--- a/src/cljs/main/broadfcui/auth.cljs
+++ b/src/cljs/main/broadfcui/auth.cljs
@@ -23,6 +23,9 @@
      (js/gapi.load "auth2" #(this :-handle-auth2-loaded)))
    :-handle-auth2-loaded
    (fn [{:keys [props]}]
+     ;; NB: we do not override the fetch_basic_profile config option on auth2.init.
+     ;; fetch_basic_profile defaults to true, and adds "openid email profile" to the
+     ;; list of requested scopes.
      (let [{:keys [on-loaded]} props
            scopes (string/join
                    " "

--- a/src/cljs/main/broadfcui/auth.cljs
+++ b/src/cljs/main/broadfcui/auth.cljs
@@ -13,6 +13,9 @@
    [broadfcui.utils.user :as user]
    ))
 
+(def login-scopes ["email" "profile"])
+(def storage-scopes (conj login-scopes "https://www.googleapis.com/auth/devstorage.read_only"))
+
 (react/defc GoogleAuthLibLoader
   {:render
    (constantly nil)
@@ -24,8 +27,7 @@
      (let [{:keys [on-loaded]} props
            scopes (string/join
                    " "
-                   ["email" "profile"
-                    "https://www.googleapis.com/auth/devstorage.full_control"])
+                   login-scopes)
            init-options (clj->js {:client_id (config/google-client-id) :scope scopes})
            auth2 (js/gapi.auth2.init init-options)]
        (gapi.signin2.render "sign-in-button" #js{:width 180 :height 40 :longtitle true :theme "dark"})

--- a/src/cljs/main/broadfcui/common.cljs
+++ b/src/cljs/main/broadfcui/common.cljs
@@ -241,3 +241,6 @@
   ([component attrs coll] (mapwrap component attrs identity coll))
   ([component attrs f coll] (map (fn [elem] [component attrs (f elem)]) coll)))
 
+;; scopes live here instead of in auth.cljs as a quick fix to avoid circular dependencies
+(def login-scopes ["email" "profile"])
+(def storage-scopes (conj login-scopes "https://www.googleapis.com/auth/devstorage.read_only"))

--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -2,7 +2,6 @@
   (:require
    [dmohs.react :as react]
    [clojure.string :as string]
-   [broadfcui.auth :as auth]
    [broadfcui.common :as common]
    [broadfcui.common.links :as links]
    [broadfcui.common.style :as style]
@@ -140,7 +139,7 @@
                                         :status status-code}))
                     (when success?
                       (let [content-type (:contentType (get-parsed-response))
-                            scopes auth/storage-scopes]
+                            scopes common/storage-scopes]
                         (when (previewable? object content-type)
                           (endpoints/call-ajax-sam
                                       {:endpoint (endpoints/pet-token (:workspace-namespace props))

--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -152,14 +152,14 @@
                                                                 (js/encodeURIComponent object) "?alt=media")
                                                          :headers {"Authorization" (str "Bearer " pet-token)
                                                                    "Range" (str "bytes=-" preview-byte-count)}
-                                                         :on-done (fn [{:keys [raw-response]}]
+                                                         :on-done (fn [{:keys [raw-response status-text]}]
                                                                     (swap! state assoc :preview raw-response
                                                                            :preview-line-count (count (clojure.string/split raw-response #"\n+")))
                                                                     (after-update
                                                                      (fn []
                                                                        (when-not (string/blank? (@refs "preview"))
                                                                          (aset (@refs "preview") "scrollTop" (aget (@refs "preview") "scrollHeight"))))))}))
-                                           (swap! state assoc :preview (str "Error reading preview: " raw-response))))})))))})))})
+                                           (swap! state assoc :preview (str "Error reading preview (" status-text "): " raw-response))))})))))})))})
 
 (react/defc- DOSPreviewDialog
   {:component-will-mount

--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -115,7 +115,9 @@
                  404 "This file was not found."
                  403 "You do not have access to this file."
                  "See details below.")
-               (if (:show-error-details? @state)
+               ;; TODO: revert this once automated testing runs are done
+               ;; (if (:show-error-details? @state)
+               (if true
                  [:div {}
                   [:pre {} error]
                   (links/create-internal {:onClick #(swap! state dissoc :show-error-details?)} "Hide detail")]

--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -149,7 +149,8 @@
                                        :on-done
                                        (fn [{:keys [success? raw-response get-parsed-response status-code status-text]}]
                                          (if success?
-                                           (let [pet-token (subs raw-response 1 (- (count raw-response) 1))]
+                                           ;; Sam endpoint returns a quoted token; dequote it.
+                                           (let [pet-token (utils/dequote raw-response)]
                                              (ajax/call {:url (str "https://www.googleapis.com/storage/v1/b/" bucket-name "/o/"
                                                                 (js/encodeURIComponent object) "?alt=media")
                                                          :headers {"Authorization" (str "Bearer " pet-token)

--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -62,15 +62,14 @@
              ;; The max-height of 206 looks random, but it's so that the top line of the log preview is half cut-off
              ;; to hint to the user that they should scroll up.
              (when-not (or data-empty hide-preview?)
-               (react/create-element
-                [:div {:data-test-id "preview-pane"
-                       :ref "preview"
-                       :style {:marginTop "1em" :whiteSpace "pre-wrap" :fontFamily "monospace"
-                               :fontSize "90%" :overflowY "auto" :maxHeight 206
-                               :backgroundColor "#fff" :padding "1em" :borderRadius 8}}
-                 (if-let [preview-content (:preview @state)]
-                   preview-content
-                   (spinner "Loading preview..."))]))]
+               (let [preview-content (:preview @state)]
+                 (react/create-element
+                  [:div {:data-test-id (if preview-content "preview-pane" "loading-preview-pane")
+                         :ref "preview"
+                         :style {:marginTop "1em" :whiteSpace "pre-wrap" :fontFamily "monospace"
+                                 :fontSize "90%" :overflowY "auto" :maxHeight 206
+                                 :backgroundColor "#fff" :padding "1em" :borderRadius 8}}
+                   (or preview-content (spinner "Loading preview..."))])))]
             (when (:loading? @state)
               (spinner "Getting file info..."))
             (when data

--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -33,7 +33,7 @@
 (react/defc- PreviewDialog
   {:render
    (fn [{:keys [props state]}]
-     (let [{:keys [dismiss object bucket-name]} props]
+     (let [{:keys [dismiss object bucket-name workspace-namespace]} props]
        [modals/OKCancelForm
         {:header "File Details"
          :data-test-id "preview-modal"
@@ -154,7 +154,7 @@
                                                     (when-not (string/blank? (@refs "preview"))
                                                       (aset (@refs "preview") "scrollTop" (aget (@refs "preview") "scrollHeight"))))))})))))})))})
 
-(react/defc DOSPreviewDialog
+(react/defc- DOSPreviewDialog
   {:component-will-mount
    (fn [{:keys [state props]}]
      (let [{:keys [dos-uri]} props]
@@ -191,15 +191,15 @@
 (defn- lrm-pad [string]
   (str (gstring/unescapeEntities "&#8206;") string (gstring/unescapeEntities "&#8206;")))
 
-(react/defc GCSFilePreviewLink
+(react/defc- GCSFilePreviewLink
   {:render
    (fn [{:keys [state props]}]
-     (let [{:keys [bucket-name object workspace-bucket link-label]} props]
+     (let [{:keys [bucket-name object workspace-bucket link-label workspace-namespace]} props]
        (assert bucket-name "No bucket name provided")
        (assert object "No GCS object provided")
        [:div (or (:attributes props) {})
         (when (:showing-preview? @state)
-          [PreviewDialog (assoc (utils/restructure bucket-name object)
+          [PreviewDialog (assoc (utils/restructure bucket-name object workspace-namespace)
                            :dismiss #(swap! state dissoc :showing-preview?))])
         [:a {:href (str "gs://" bucket-name "/" object)
              :onClick (fn [e]
@@ -210,7 +210,7 @@
              object
              (if link-label (str link-label) (str "gs://" bucket-name "/" object))))]]))})
 
-(react/defc DOSFilePreviewLink
+(react/defc- DOSFilePreviewLink
   {:render
    (fn [{:keys [state props]}]
      (let [{:keys [dos-uri link-label]} props]

--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -188,8 +188,10 @@
           (when (:showing-preview? @state)
             (if-let [parsed (common/parse-gcs-uri data)]
               [PreviewDialog (assoc parsed
+                               :workspace-namespace (:workspace-namespace props)
                                :dismiss (:dismiss props))]
               [PreviewDialog (assoc props :error error :object ""
+                               :workspace-namespace (:workspace-namespace props)
                                :dismiss (:dismiss props))])))]))})
 
 ;; Sometimes we apply an RTL rule so that long links overflow and show ellipses on the left-hand side.
@@ -220,10 +222,11 @@
 (react/defc- DOSFilePreviewLink
   {:render
    (fn [{:keys [state props]}]
-     (let [{:keys [dos-uri link-label]} props]
+     (let [{:keys [dos-uri link-label workspace-namespace]} props]
        [:div (or (:attributes props) {})
         (when (:showing-preview? @state)
           [DOSPreviewDialog (assoc props
+                              :workspace-namespace workspace-namespace
                               :dos-uri dos-uri
                               :dismiss #(swap! state dissoc :showing-preview?))])
         [:a {:href dos-uri

--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -160,7 +160,9 @@
                                                                        (when-not (string/blank? (@refs "preview"))
                                                                          (aset (@refs "preview") "scrollTop" (aget (@refs "preview") "scrollHeight"))))))}))
                                            (let [err-code (if (string/blank? status-text) status-code status-text)
-                                                 err-message (or (:message (get-parsed-response) raw-response))]
+                                                 [error-json parsing-error] (get-parsed-response true false)
+                                                 trunc-response (subs raw-response 0 140)
+                                                 err-message (if parsing-error trunc-response (or (:message (get-parsed-response) trunc-response)))]
                                              (swap! state assoc :preview (str "Error reading preview (" err-code "): " err-message)))))})))))})))})
 
 (react/defc- DOSPreviewDialog

--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -41,6 +41,8 @@
          :dismiss dismiss
          :content
          (let [{:keys [data error status]} (:response @state)
+               [parsed-error _] (when error (utils/parse-json-string error true false))
+               parsed-error-message (when parsed-error (:message parsed-error))
                data-size (:size data)
                cost (:estimatedCostUSD data)
                labeled (fn [label & contents]
@@ -114,10 +116,8 @@
                (case status
                  404 "This file was not found."
                  403 "You do not have access to this file."
-                 "See details below.")
-               ;; TODO: revert this once automated testing runs are done
-               ;; (if (:show-error-details? @state)
-               (if true
+                 (or parsed-error-message "See details below."))
+               (if (:show-error-details? @state)
                  [:div {}
                   [:pre {} error]
                   (links/create-internal {:onClick #(swap! state dissoc :show-error-details?)} "Hide detail")]

--- a/src/cljs/main/broadfcui/common/table/utils.cljs
+++ b/src/cljs/main/broadfcui/common/table/utils.cljs
@@ -129,12 +129,13 @@
         (sequential? data) (string/join ", " data)
         :else (str data)))
 
-(defn render-gcs-links [workspace-bucket]
+(defn render-gcs-links [workspace-bucket workspace-namespace]
   (fn [maybe-uri]
     (if-let [parsed (common/dos-or-gcs-uri? maybe-uri)]
       [FilePreviewLink
        (assoc parsed
          :workspace-bucket workspace-bucket
+         :workspace-namespace workspace-namespace
          :attributes {:style {:direction "rtl" :marginRight "0.5em"
                               :overflow "hidden" :textOverflow "ellipsis"
                               :textAlign "left"}})]

--- a/src/cljs/main/broadfcui/endpoints.cljs
+++ b/src/cljs/main/broadfcui/endpoints.cljs
@@ -26,6 +26,10 @@
    (:path endpoint)
    (ajax-payload endpoint arg-map)))
 
+(defn call-ajax-sam [{:keys [endpoint] :as arg-map}]
+  (ajax/call-sam
+   (:path endpoint)
+   (ajax-payload endpoint arg-map)))
 
 (defn- id-path [id]
   (str (:namespace id) "/" (:name id)))
@@ -201,6 +205,10 @@
 (defn proxy-group [email]
   {:path (str "/proxyGroup/" email)
    :method :get})
+
+(defn pet-token [project]
+  {:path (str "/google/v1/user/petServiceAccount/" project "/token")
+   :method :post})
 
 (defn list-method-snapshots [namespace name]
   {:path (str "/methods?namespace=" namespace "&name=" name)

--- a/src/cljs/main/broadfcui/page/workspace/analysis/igv.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/analysis/igv.cljs
@@ -1,7 +1,6 @@
 (ns broadfcui.page.workspace.analysis.igv
   (:require
    [dmohs.react :as react]
-   [broadfcui.auth :as auth]
    [broadfcui.common :as common]
    [broadfcui.common.style :as style]
    [broadfcui.components.script-loader :refer [ScriptLoader]]
@@ -73,7 +72,7 @@
          ;; when the user DOES have tracks, get a token for the user's pet, then pass that token into the IGV tracks.
          (endpoints/call-ajax-sam
            {:endpoint (endpoints/pet-token (get-in props [:workspace-id :namespace]))
-            :payload auth/storage-scopes
+            :payload common/storage-scopes
             :headers ajax/content-type=json
             :on-done
               (fn [{:keys [success? raw-response]}]

--- a/src/cljs/main/broadfcui/page/workspace/analysis/igv.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/analysis/igv.cljs
@@ -28,6 +28,7 @@
                              {:name (str "Track " (inc index))
                               :url (common/gcs-uri->google-url track-url)
                               :indexURL (when (string? @index-url) (common/gcs-uri->google-url @index-url))
+                              ;; we expect a pet token passed as argument to this function.
                               :headers {"Authorization" (str "Bearer " token)}
                               :displayMode "EXPANDED"
                               :height (when bam? 200)
@@ -65,7 +66,6 @@
    :refresh
    (fn [{:keys [props refs]}]
      (let [tracks (:tracks props)]
-       (utils/log tracks)
        (if (empty? tracks)
          ;; if the user hasn't specified any tracks, render the IGV shell without getting a pet token
          (.createBrowser js/igv (@refs "container") (options [] ""))
@@ -77,7 +77,8 @@
             :on-done
               (fn [{:keys [success? raw-response]}]
                 (if success?
-                  (let [pet-token (subs raw-response 1 (- (count raw-response) 1))]
+                  ;; Sam endpoint returns a quoted token; dequote it.
+                  (let [pet-token (utils/dequote raw-response)]
                     (.createBrowser js/igv (@refs "container") (options (:tracks props) pet-token)))
                   ;; TODO: better error display
                   (js/alert raw-response)))}))))})

--- a/src/cljs/main/broadfcui/page/workspace/analysis/tab.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/analysis/tab.cljs
@@ -26,7 +26,8 @@
            :dismiss #(swap! state dissoc :show-track-selection-dialog?)
            :tracks (:tracks @state)
            :on-ok #(swap! state assoc :tracks %))])
-      [IGVContainer {:tracks (:tracks @state)}]
+      [IGVContainer {:tracks (:tracks @state)
+                     :workspace-id (:workspace-id props)}]
       [buttons/Button {:text "Select Tracks..."
                        :style {:float "right" :marginTop "1rem"}
                        :onClick #(swap! state assoc :show-track-selection-dialog? true)}]

--- a/src/cljs/main/broadfcui/page/workspace/data/copy_data_entities.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/data/copy_data_entities.cljs
@@ -28,6 +28,7 @@
         [EntitySelector {:ref "EntitySelector"
                          :type (:type props)
                          :selected-workspace-bucket (:selected-workspace-bucket props)
+                         :workspace-namespace (get-in props [:workspace-id :namespace])
                          :left-text (str (string/capitalize (:type props)) "s in " (:namespace swid) "/" (:name swid))
                          :right-text "To be imported"
                          :id-name (:id-name props)

--- a/src/cljs/main/broadfcui/page/workspace/data/entity_selector.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/data/entity_selector.cljs
@@ -54,7 +54,7 @@
                                       (if (and (map? attr-value)
                                                (= (set (keys attr-value)) #{:entityName :entityType}))
                                         (:entityName attr-value)
-                                        ((table-utils/render-gcs-links (:selected-workspace-bucket props)) attr-value)))})
+                                        ((table-utils/render-gcs-links (:selected-workspace-bucket props) (:workspace-namespace props)) attr-value)))})
                            attribute-keys)))
            data (fn [source?]
                   (replace

--- a/src/cljs/main/broadfcui/page/workspace/data/entity_viewer.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/data/entity_viewer.cljs
@@ -115,6 +115,7 @@
                                             (if-let [parsed (common/dos-or-gcs-uri? v)]
                                               {:for-sort (string/lower-case v)
                                                :for-render [FilePreviewLink (assoc parsed
+                                                                              :workspace-namespace (get-in props [:workspace-id :namespace])
                                                                               :attributes {:style {:display "inline"}}
                                                                               :link-label v)]}
                                               {:for-sort (string/lower-case (str v))

--- a/src/cljs/main/broadfcui/page/workspace/data/tab.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/data/tab.cljs
@@ -106,7 +106,7 @@
                               :onClick #(swap! state assoc :show-importer? true)}]])
           :on-entity-type-selected #(utils/multi-swap! state (assoc :selected-entity-type %) (dissoc :selected-entity))
           :on-column-change #(swap! state assoc :visible-columns %)
-          :attribute-renderer (table-utils/render-gcs-links (get-in workspace [:workspace :bucketName]))
+          :attribute-renderer (table-utils/render-gcs-links (get-in workspace [:workspace :bucketName]) (get-in workspace [:workspace :namespace]))
           :linked-entity-renderer
           (fn [entity]
             (if (map? entity)

--- a/src/cljs/main/broadfcui/page/workspace/summary/attribute_editor.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/summary/attribute_editor.cljs
@@ -208,7 +208,7 @@
                                {:id "value" :header (header "Value") :initial-width :auto
                                 :column-data val
                                 :as-text process-attribute-value
-                                :render (comp (table-utils/render-gcs-links (:workspace-bucket props)) process-attribute-value)}])}
+                                :render (comp (table-utils/render-gcs-links (:workspace-bucket props) (get-in props [:workspace-id :namespace])) process-attribute-value)}])}
             :paginator :none}]]}]))
    :component-did-update
    (fn [{:keys [prev-props props state]}]

--- a/src/cljs/main/broadfcui/utils.cljs
+++ b/src/cljs/main/broadfcui/utils.cljs
@@ -17,6 +17,12 @@
   (<= 0 (str-index-of s what)))
 
 
+(defn dequote [s]
+  (if (and (string/starts-with? s "\"") (string/ends-with? s "\""))
+    (subs s 1 (- (count s) 1))
+    s))
+
+
 (defn ->json-string [x]
   (js/JSON.stringify (clj->js x)))
 


### PR DESCRIPTION
There's a ton of comments and retests below, but after multiple rounds of bugfixing in test code and rawls, I think we're at the right place.

This PR changes the behavior of the file preview modal and IGV. In both use cases, because the UI makes calls to GCS APIs, we call out to Sam to get a pet token for the user. We then use the pet token for the GCS calls, which allows us to _not_ request OAuth storage scope from the user.

To get the pet token, I had to make a lot of small code changes to pass the current workspace's namespace (i.e. the Google project) into various components and functions. With the namespace in hand, we can get the pet token from that project.

I also have made multiple tweaks to better expose underlying error messages to the end user in the preview modal. This is good for UX *and* very helpful in debugging tests, because the errors are more likely to appear in test-failure screenshots.

broadinstitute/workbench-libs#148 updates automated tests to remove the OAuth storage scope from test access tokens. My plan:
1. in this PR, include a snapshot version of `workbench-service-test` with the OAuth changes, so that PR tests are valid.
2. merge workbench-libs, which will publish a real version.
3. update this PR to the real version of `workbench-service-test`
4. merge this PR


