### PR TITLE
use CSS pseudo-elements instead of text for LTR marks

### DIFF
--- a/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
+++ b/src/cljs/main/broadfcui/common/gcs_file_preview.cljs
@@ -201,12 +201,6 @@
                                :workspace-namespace (:workspace-namespace props)
                                :dismiss (:dismiss props))])))]))})
 
-;; Sometimes we apply an RTL rule so that long links overflow and show ellipses on the left-hand side.
-;; Go back to LTR here so we do not reorder the object name. Both the leading and trailing instances
-;; are necessary to cover all cases. (GAWB-2495, GAWB-1912)
-(defn- lrm-pad [string]
-  (str (gstring/unescapeEntities "&#8206;") string (gstring/unescapeEntities "&#8206;")))
-
 (react/defc- GCSFilePreviewLink
   {:render
    (fn [{:keys [state props]}]
@@ -218,13 +212,13 @@
           [PreviewDialog (assoc (utils/restructure bucket-name object workspace-namespace)
                            :dismiss #(swap! state dissoc :showing-preview?))])
         [:a {:href (str "gs://" bucket-name "/" object)
+             :class "ltr-marked"
              :onClick (fn [e]
                         (.preventDefault e)
                         (swap! state assoc :showing-preview? true))}
-         (lrm-pad
            (if (= bucket-name workspace-bucket)
              object
-             (if link-label (str link-label) (str "gs://" bucket-name "/" object))))]]))})
+             (if link-label (str link-label) (str "gs://" bucket-name "/" object)))]]))})
 
 (react/defc- DOSFilePreviewLink
   {:render
@@ -237,10 +231,11 @@
                               :dos-uri dos-uri
                               :dismiss #(swap! state dissoc :showing-preview?))])
         [:a {:href dos-uri
+             :class "ltr-marked"
              :onClick (fn [e]
                         (.preventDefault e)
                         (swap! state assoc :showing-preview? true))}
-         (lrm-pad (if link-label (str link-label) dos-uri))]]))})
+         (if link-label (str link-label) dos-uri)]]))})
 
 (react/defc FilePreviewLink
   {:render

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -26,6 +26,9 @@
       *:disabled {
         cursor: not-allowed;
       }
+      .ltr-marked::before, .ltr-marked::after {
+        content: "\200E";
+      }
     </style>
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
 </head>


### PR DESCRIPTION
See also:
* #1267
* https://broadinstitute.atlassian.net/browse/GAWB-2495
* https://broadinstitute.atlassian.net/browse/GAWB-1912
* https://broadinstitute.atlassian.net/browse/GAWB-1216
and more ... 

The solution to the combination of (left-ellipses AND (trailing punctuation OR numeric filenames)) in #1267 was to pad the string value at both start and end with the LTR mark (unicode [200E](https://www.compart.com/en/unicode/U+200E)). However, this broke copying, because the LTR mark was included when selecting the text and then copying it.

In this PR, I change how we pad the string value - I'm using the CSS `::before` and `::after` pseudo-elements instead of directly changing the text. Since pseudo-elements are not selectable/copyable, this fixes the copy issue.

databiosphere/firecloud-app#110 has a list of test cases to check.

