### PR TITLE
remove google analytics in favor of new relic

### DIFF
--- a/src/static/google-analytics.js
+++ b/src/static/google-analytics.js
@@ -1,7 +1,0 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-ga('create', 'UA-64736463-1', 'auto');
-ga('send', 'pageview');

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,7 +8,6 @@
     <link href='//fonts.googleapis.com/css?family=Roboto:400,500,700'
           rel='stylesheet' type='text/css'>
     <script src="https://apis.google.com/js/platform.js"></script>
-    <script type="text/javascript" src="google-analytics.js"></script>
     <script type="text/javascript" src="newrelic.js"></script>
     <style>
       body {


### PR DESCRIPTION
remove google analytics. We have been using new relic analytics for a while now and it seems to suit our requirements; no need to have both.

databiosphere/firecloud-app#131