### PR TITLE
eliminate extra expensive ajax calls on workspace tab-change

### DIFF
--- a/src/cljs/main/broadfcui/page/workspace/details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/details.cljs
@@ -164,7 +164,7 @@
      (this :-refresh-workspace))
    :component-will-receive-props
    (fn [{:keys [props next-props this after-update]}]
-     (when (and false (utils/any-change [:tab-name :workspace-id] props next-props))
+     (when (utils/any-change [:workspace-id] props next-props)
        (after-update this :-refresh-workspace)))
    :-refresh-workspace
    (fn [{:keys [props state]}]

--- a/src/cljs/main/broadfcui/page/workspace/details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/details.cljs
@@ -164,7 +164,7 @@
      (this :-refresh-workspace))
    :component-will-receive-props
    (fn [{:keys [props next-props this after-update]}]
-     (when (utils/any-change [:tab-name :workspace-id] props next-props)
+     (when (and false (utils/any-change [:tab-name :workspace-id] props next-props))
        (after-update this :-refresh-workspace)))
    :-refresh-workspace
    (fn [{:keys [props state]}]


### PR DESCRIPTION
The call to `-refresh-workspace` inside `component-will-receive-props` means that every time we switch tabs inside a workspace, we fire off two ajax calls - one to GET the workspace details, and another to `checkBucketReadAccess`. Both of these calls are relatively expensive.

We originally added this refresh for two reasons:
1. fix https://broadinstitute.atlassian.net/browse/GAWB-2485; see
#916.
2. ensure that each tab shows the most updated data, such as in cases where another user locked or edited the workspace while the current user is browsing.

Other PRs that may be relevant: #1118, #1125, #1253

I am removing the refresh - except in the case of workspace clone - to assist with scaling. The tradeoff is that if another user changes the workspace in a significant way, the current user must leave the workspace entirely and re-enter (or refresh the entire browser) to see the changes.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [ ] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
