### PR TITLE
fix abort button visibility for completed submissions

### DIFF
--- a/src/cljs/main/broadfcui/page/workspace/monitor/submission_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/submission_details.cljs
@@ -169,7 +169,7 @@
                                :color (color-for-submission submission)
                                :icon (icon-for-submission submission)}]
            (when (and
-                   contains? moncommon/sub-running-statuses (:status submission)
+                   (contains? moncommon/sub-running-statuses (:status submission))
                    (common/access-greater-than-equal-to? (:user-access-level props) "WRITER"))
              [AbortButton
               {:on-abort (fn []


### PR DESCRIPTION
follow-on PR to #1397.

This PR fixes a sloppy syntax error that caused the abort button to always appear for owners, even on finished (completed, already aborted) submissions.