### PR TITLE
add git revision to UI html source [risk: medium]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2665,6 +2665,12 @@
         "assert-plus": "1.0.0"
       }
     },
+    "git-revision-webpack-plugin": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/git-revision-webpack-plugin/-/git-revision-webpack-plugin-3.0.3.tgz",
+      "integrity": "sha512-B2ixM0fY7VgR61ZRSXYrh0R57Er7RY+CZb+fja5OFe21Y5o9GgzQanMgdlcBwWZ+LoOVqxBogbDutTTYMXQDWw==",
+      "dev": true
+    },
     "github-markdown-css": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-2.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "css-loader": "^0.28.9",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.6",
+    "git-revision-webpack-plugin": "^3.0.3",
     "node-sass": "4.6.1",
     "rebuild-node-sass": "^1.1.0",
     "sass-loader": "^6.0.6",

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-type" content="text/html;charset=utf-8">
     <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="application-name" content="FireCloud"
+      data-revision="{{gitversion}}"
+      data-commithash="{{githash}}">
     <title>FireCloud | Broad Institute</title>
     <link href='//fonts.googleapis.com/css?family=Roboto:400,500,700'
           rel='stylesheet' type='text/css'>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const webpack = require('webpack');
+const GitRevisionPlugin = require('git-revision-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
@@ -10,6 +10,8 @@ const definePlugin = new webpack.DefinePlugin({
     }
 });
 
+const gitRevisionPlugin = new GitRevisionPlugin();
+
 const copyWebpackPlugin = new CopyWebpackPlugin([{
     context: 'src/static',
     from: {
@@ -17,10 +19,23 @@ const copyWebpackPlugin = new CopyWebpackPlugin([{
         dot: false
     },
     transform: function (content, path) {
-        if (path.endsWith('.html'))
-            return content.toString().replace(/{{vtag}}/g, Date.now());
-        else
+        if (path.endsWith('.html')) {
+            let version = "n/a";
+            let hash = "n/a";
+            try {
+                version = gitRevisionPlugin.version();
+                hash = gitRevisionPlugin.commithash();
+            } catch (err) {
+                // noop - likely executing in a local docker container without a .git directory
+            }
+
+            return content.toString()
+                .replace(/{{vtag}}/g, Date.now())
+                .replace(/{{gitversion}}/g, version)
+                .replace(/{{githash}}/g, hash);
+        } else {
             return content;
+        }
     }
 }]);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const GitRevisionPlugin = require('git-revision-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');


### PR DESCRIPTION
I got frustrated always wondering which version of the app was running in which environment.

This PR adds git revision/hash to the HTML source as a meta tag. Developers/admins/other interested parties can just view-source on the FireCloud UI to know which specific commit is in use.

The `try/catch` in webpack.config.js should make this code resilient to environments where git information isn't available - notably, running the UI via `./config/docker-rsync-local-ui.sh`. In that local environment, we rsync codebases into a docker volume and don't sync the `.git` directory. But in Jenkins builds, this information should be available; I verified by starting a custom fiab and saw source of:
```

<html>
  <head profile="http://www.w3.org/2005/10/profile">
  <meta charset="utf-8">
  <meta http-equiv="Content-type" content="text/html;charset=utf-8">
  <meta name="viewport" content="initial-scale=1,width=device-width">
  <meta name="application-name" content="FireCloud"
    data-revision="fisma-r1-1455-g734c37a0"
    data-commithash="734c37a03a7752cc5494dab2acd7e7f149e1ad58">
  <title>FireCloud | Broad Institute</title>
```

I'm very conservatively labeling this `[risk:medium]` instead of low. Potentially, an attacker could use the revision information to see which bugs/vulnerabilities have been fixed since the commit in use. However, since our github repo is open-source anyway, this doesn't actually give the attacker any new information - it just makes it slightly easier to know which code is in use when.