### PR TITLE
ontology autocomplete: handle out-of-order ajax [risk: low]

### DIFF
--- a/src/cljs/main/broadfcui/components/autosuggest.cljs
+++ b/src/cljs/main/broadfcui/components/autosuggest.cljs
@@ -68,6 +68,7 @@
                              get-suggestions (fn [value]
                                                (get-suggestions (.-value value) #(swap! state assoc :suggestions %)))
                              url (fn [value]
+                                   ;; this is called in response to user keystrokes. Here, <value> represents the current user input.
                                    (swap! state assoc :latest-input value)
                                    (ajax/call-orch
                                     (str url (.-value value))
@@ -80,6 +81,9 @@
                                                                        (get-parsed-response false))
                                                                      [:error])
                                                       updated-result-map (assoc result-map value ajax-results)]
+                                                  ;; this is called in response to an ajax request returning. Here, <value> represents the argument sent to the
+                                                  ;; ajax request, and we need to look to <(:latest-input @state)> to see the current user input.
+                                                  ;;
                                                   ;; save results for this ajax request - which may not be current - to state
                                                   (swap! state assoc :ajax-result-map updated-result-map)
                                                   ;; extract results from state for the current input value


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WB-88

Our ontology autosuggest makes an ajax request every time the user enters a character into the input field. When a user - or an automated test - enters characters rapidly, we fire off multiple ajax requests in succession, and because ajax is asynchronous, we can receive those results out of order.

This PR makes an effort to match the ajax results to the inputs, tracks which is the most recent value input by the user, and displays results only for the most recent input.

-----

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [ ] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
