### PR TITLE
lazy load inputs and outputs [risk: low]

### DIFF
--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -310,8 +310,8 @@
                   (create-field "Cache Result" (moncommon/format-call-cache (get (data "callCaching") "hit"))))
                 (create-field "Started" (moncommon/render-date (data "start")))
                 (create-field "Ended" (moncommon/render-date (data "end")))
-                [IODetail {:label "Inputs" :data-path ["calls" label index "inputs"] :data-fn inputs-fn :data inputs-data :call-detail? true :workspace-id (:workspace-id props)}]
-                [IODetail {:label "Outputs" :data-path ["calls" label index "outputs"] :data-fn outputs-fn :data outputs-data :call-detail? true :workspace-id (:workspace-id props)}]
+                [IODetail {:label "Inputs" :data-path ["calls" label index "inputs"] :data-fn inputs-fn :data inputs-data :call-detail? (not (data "subWorkflowId")) :workspace-id (:workspace-id props)}]
+                [IODetail {:label "Outputs" :data-path ["calls" label index "outputs"] :data-fn outputs-fn :data outputs-data :call-detail? (not (data "subWorkflowId")) :workspace-id (:workspace-id props)}]
                 (when-let [stdout (data "stdout")]
                   (create-field "stdout" (display-value workspace-namespace stdout (last (string/split stdout #"/")))))
                 (when-let [stderr (data "stderr")]

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -101,11 +101,11 @@
                       task-column {:header "Task"
                                     :column-data #(second (string/split (key %) #"\."))}]
                   [Table
-                    {:data usable-data
+                   {:data usable-data
                     :body {:style table-style/table-heavy
-                            :behavior {:reorderable-columns? false
+                           :behavior {:reorderable-columns? false
                                       :filterable? false}
-                            :columns (if (:call-detail? props) columns (cons task-column columns))}}])])))]))})
+                           :columns (if (:call-detail? props) columns (cons task-column columns))}}])])))]))})
 
 (react/defc- WorkflowTimingDiagram
   {:render

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -86,7 +86,7 @@
               [:div {:style {:padding "0.25em 0 0.5em 1em" :font-style "italic"}} (str "No " (:label props) ".")]
             :else
               ;; some portions of the metadata response from Cromwell are escaped json strings (e.g. submittedFiles/inputs),
-              ;; instead of valid json. hHndle that transparently here: if we detect the target data is a string, attempt to parse it.
+              ;; instead of valid json. Handle that transparently here: if we detect the target data is a string, attempt to parse it.
               (let [raw-data (get-in data (cons :response data-path))
                     usable-data (if (string? raw-data) (utils/parse-json-string raw-data) raw-data)]
                 [:div {:style {:padding "0.25em 0 0.25em 1em"}}
@@ -402,8 +402,7 @@
                                    (:workspace-id props) workflow-path-prefix
                                    #(this :get-inputs) (:metadata-inputs @state)
                                    #(this :get-outputs) (:metadata-outputs @state)
-                                   (:subworkflow? props)
-                                   )))))
+                                   (:subworkflow? props))))))
    :component-did-mount
    (fn [{:keys [props state]}]
      (endpoints/call-ajax-orch

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -43,7 +43,11 @@
 
 (defonce metadata-inputs-includes ["submittedFiles:inputs" "inputs"])
 
-(defonce metadata-outputs-includes ["outputs"])
+;; requesting executionStatus for outputs makes the response payload somewhat larger, but it forces Cromwell to return
+;; data about every call in a task scatter. Otherwise, if we request just includeKey=outputs and a scatter contains both
+;; successes and failures, Cromwell will return only those calls that have outputs, i.e. the successes. Since our CLJS code
+;; identifies calls by their index in an array, this causes off-by-one (or off-by-many) functional errors.
+(defonce metadata-outputs-includes ["executionStatus" "outputs"])
 
 (defn getTimingDiagramHeight [chartContainer]
   (let [e (-> chartContainer (.-childNodes)

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -82,29 +82,29 @@
               (spinner (str "Loading " (:label props) "...")) ;; show a spinner while data from the onClick loads
             (not (:success? data))
               (style/create-inline-error-message (:response data))
-            (empty? (get-in data (cons :response data-path)))
-              [:div {:style {:padding "0.25em 0 0.5em 1em" :font-style "italic"}} (str "No " (:label props) ".")]
             :else
               ;; some portions of the metadata response from Cromwell are escaped json strings (e.g. submittedFiles/inputs),
               ;; instead of valid json. Handle that transparently here: if we detect the target data is a string, attempt to parse it.
               (let [raw-data (get-in data (cons :response data-path))
                     usable-data (if (string? raw-data) (utils/parse-json-string raw-data) raw-data)]
-                [:div {:style {:padding "0.25em 0 0.25em 1em"}}
-                (let [namespace (get-in props [:workspace-id :namespace])
-                      columns [{:header "Label"
-                                :column-data #(last (string/split (key %) #"\."))}
-                                {:header "Value"
-                                :initial-width :auto
-                                :sortable? false
-                                :column-data #(display-value namespace (second %))}]
-                      task-column {:header "Task"
-                                    :column-data #(second (string/split (key %) #"\."))}]
-                  [Table
-                   {:data usable-data
-                    :body {:style table-style/table-heavy
-                           :behavior {:reorderable-columns? false
-                                      :filterable? false}
-                           :columns (if (:call-detail? props) columns (cons task-column columns))}}])])))]))})
+                (if (empty? usable-data)
+                  [:div {:style {:padding "0.25em 0 0.5em 1em" :font-style "italic"}} (str "No " (:label props) ".")]
+                  [:div {:style {:padding "0.25em 0 0.25em 1em"}}
+                    (let [namespace (get-in props [:workspace-id :namespace])
+                          columns [{:header "Label"
+                                    :column-data #(last (string/split (key %) #"\."))}
+                                   {:header "Value"
+                                    :initial-width :auto
+                                    :sortable? false
+                                    :column-data #(display-value namespace (second %))}]
+                          task-column {:header "Task"
+                                       :column-data #(second (string/split (key %) #"\."))}]
+                      [Table
+                       {:data usable-data
+                        :body {:style table-style/table-heavy
+                               :behavior {:reorderable-columns? false
+                                          :filterable? false}
+                               :columns (if (:call-detail? props) columns (cons task-column columns))}}])]))))]))})
 
 (react/defc- WorkflowTimingDiagram
   {:render

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -73,14 +73,13 @@
        [:div {}
         (create-field
          (:label props)
-           (links/create-internal {:onClick #(swap! state update :expanded not)}
+           ;; when the user clicks to expand, trigger the request to get data
+           (links/create-internal {:onClick #(when (:expanded (swap! state update :expanded not)) (data-fn))}
              (if (:expanded @state) "Hide" "Show")))
         (when (:expanded @state)
           (cond
             (nil? data)
-              (do
-                (data-fn) ;; trigger the request to get data
-                (spinner (str "Loading " (:label props) "..."))) ;; and show a spinner while data loads
+              (spinner (str "Loading " (:label props) "...")) ;; show a spinner while data from the onClick loads
             (not (:success? data))
               (style/create-inline-error-message (:response data))
             (empty? (get-in data (cons :response data-path)))
@@ -339,7 +338,6 @@
                           :response (if success? (:cost (get-parsed-response)) (str "Error: " (or (:message (get-parsed-response)) status-text)))}))}))})
 
 (defn- render-workflow-detail [workflow raw-data workflow-name submission-id use-call-cache workspace-id gcs-path-prefix inputs-fn inputs-data outputs-fn outputs-data subworkflow?]
-  (utils/log (str "render-workflow-detail for " (workflow "id") " thinks subworkflow?  is " subworkflow? ))
   (let [inputs (ffirst (workflow "calls"))
         input-names (string/split inputs ".")
         workflow-name-for-path (first input-names)

--- a/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
+++ b/src/cljs/main/broadfcui/page/workspace/monitor/workflow_details.cljs
@@ -102,7 +102,7 @@
                                     :sortable? false
                                     :column-data #(display-value namespace (second %))}]
                           task-column {:header "Task"
-                                       :column-data #(second (string/split (key %) #"\."))}]
+                                       :column-data #(second (rseq (string/split (key %) #"\.")))}]
                       [Table
                        {:data usable-data
                         :body {:style table-style/table-heavy


### PR DESCRIPTION
DataBiosphere/firecloud-app#215
also fixes DataBiosphere/firecloud-app#231 while I'm in there

Goal of this PR is lighten the initial workflow metadata query to not retrieve inputs or outputs info, thus making it smaller; and then only request the input/output data on demand if a user chooses to expand one of those sections.

On the workflow detail page, we have:
* 1 `WorkflowDetails` component, which contains:
  * 1-N `CallDetail` components, which contain:
    * 0-N `IODetail` components
    * 0-N `WorkflowDetails` components to handle subworkflows (yes this recurses)

Previously, the `WorkflowDetails` component made a single request for workflow metadata + inputs + outputs, then passed data down the tree as props into children `IODetail`s, which handle display of inputs and outputs..

In this PR, the `WorkflowDetails` component requests the main metadata and passes it as props to child `IODetails`. It also passes separate - initially nil - props for input data and output data, as well as an `input-fn` and an `output-fn`, which are references to functions defined on the `WorkflowDetails` component . When any child `IODetails` needs to display input or output data, the child component executes the `input-fn`/`output-fn`. This triggers the `WorkflowDetails` to make an additional ajax request for the appropriate data, which it caches in its state. React handles automatically updating the child components, via props, with the updated data.

We only load subworkflow information on demand, once a user expands to see the subworkflow. Previously, we had separate functions/components to handle subworkflows, which means I would have had to implement the same kind of state-lifting logic in the subworkflow components. Instead, I have deleted the subworkflow-specific component/function and driven it all through `WorkflowDetails`, so subworkflows automatically inherit the lazy-loading of inputs/outputs.

-----
   

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [ ] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
