### PR TITLE
GAWB-3840: add test to check reader can see published dataset

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/library/PublishSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/library/PublishSpec.scala
@@ -139,7 +139,7 @@ class PublishSpec extends FreeSpec with WebBrowserSpec with UserFixtures with Wo
             withWorkspace(billingProject, "PublishSpec_curator_publish_") { wsName =>
               val data = LibraryData.metadataBasic + ("library:datasetName" -> wsName)
               api.library.setLibraryAttributes(billingProject, wsName, data)
-              api.library.setDiscoverableGroups(billingProject, wsName, List("no_users"))
+              api.library.setDiscoverableGroups(billingProject, wsName, List("demo_users"))
               api.library.publishWorkspace(billingProject, wsName)
 
               //clone workspace

--- a/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/library/PublishSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/library/PublishSpec.scala
@@ -139,6 +139,7 @@ class PublishSpec extends FreeSpec with WebBrowserSpec with UserFixtures with Wo
             withWorkspace(billingProject, "PublishSpec_curator_publish_") { wsName =>
               val data = LibraryData.metadataBasic + ("library:datasetName" -> wsName)
               api.library.setLibraryAttributes(billingProject, wsName, data)
+              api.library.setDiscoverableGroups(billingProject, wsName, List("no_users"))
               api.library.publishWorkspace(billingProject, wsName)
 
               //clone workspace


### PR DESCRIPTION
This test won't pass until the new code is merged to dev.


- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [ ] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
