### PR TITLE
skip tests: remove newrelic.js from more places [no ticket;  risk: no]

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/builddeploy/BuildDeploySpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/firecloud/test/builddeploy/BuildDeploySpec.scala
@@ -26,7 +26,7 @@ class BuildDeploySpec extends FreeSpec with WebBrowserSpec with Matchers with La
     }
 
     // these tests ensure that the build/deploy process has generated files at the correct urls
-    List("tcell.js","newrelic.js","assets/favicon.ico").foreach { partialUrl =>
+    List("tcell.js","assets/favicon.ico").foreach { partialUrl =>
 
       s"should put $partialUrl in the right place" in {
         withWebDriver { implicit driver =>

--- a/src/docker/override.sh
+++ b/src/docker/override.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Make sure config.json, newrelic.js, and tcell.js are in the right spot
-CONFIG_FILES="/config/config.json /config/newrelic.js /config/tcell.js"
+# Make sure config.json, and tcell.js are in the right spot
+CONFIG_FILES="/config/config.json /config/tcell.js"
 cp -f ${CONFIG_FILES} /var/www/html
 
 if [ "${HTTPS_ONLY}" = 'true' ]; then

--- a/src/docker/site-https-only.conf
+++ b/src/docker/site-https-only.conf
@@ -29,7 +29,6 @@ Header always set X-Frame-Options SAMEORIGIN
     </Directory>
 
     Alias /config.json /var/www/html/config.json
-    Alias /newrelic.js /var/www/html/newrelic.js
     Alias /tcell.js /var/www/html/tcell.js
 </VirtualHost>
 
@@ -56,7 +55,6 @@ Header always set X-Frame-Options SAMEORIGIN
     </Directory>
 
     Alias /config.json /var/www/html/config.json
-    Alias /newrelic.js /var/www/html/newrelic.js
     Alias /tcell.js /var/www/html/tcell.js
 </VirtualHost>
 

--- a/src/docker/site-https-only.conf
+++ b/src/docker/site-https-only.conf
@@ -58,7 +58,7 @@ Header always set X-Frame-Options SAMEORIGIN
     Alias /tcell.js /var/www/html/tcell.js
 </VirtualHost>
 
-<FilesMatch "(^index\.html|config\.json|newrelic\.js|tcell\.js)">
+<FilesMatch "(^index\.html|config\.json|tcell\.js)">
   Header set Cache-Control "no-store, no-cache, must-revalidate"
   Header set Pragma "no-cache"
   Header set Expires 0

--- a/src/docker/site.conf
+++ b/src/docker/site.conf
@@ -38,7 +38,6 @@ DocumentRoot /app/target
 </Directory>
 
 Alias /config.json /var/www/html/config.json
-Alias /newrelic.js /var/www/html/newrelic.js
 Alias /tcell.js /var/www/html/tcell.js
 
 <FilesMatch "(^index\.html|config\.json|newrelic\.js|tcell\.js)">

--- a/src/docker/site.conf
+++ b/src/docker/site.conf
@@ -40,7 +40,7 @@ DocumentRoot /app/target
 Alias /config.json /var/www/html/config.json
 Alias /tcell.js /var/www/html/tcell.js
 
-<FilesMatch "(^index\.html|config\.json|newrelic\.js|tcell\.js)">
+<FilesMatch "(^index\.html|config\.json|tcell\.js)">
   Header set Cache-Control "no-store, no-cache, must-revalidate"
   Header set Pragma "no-cache"
   Header set Expires 0


### PR DESCRIPTION
#1576 was incomplete; this removes newrelic.js from more places.

broadinstitute/firecloud-develop#2162 removed newrelic.js from config, so this PR is necessary to prevent override.sh from looking for that file.