### PR TITLE
De-duplicate ACCESS_TOKEN generation and log submission details responses [BW-687]

### DIFF
--- a/automation/prod-workflow-inc.sh
+++ b/automation/prod-workflow-inc.sh
@@ -86,7 +86,7 @@ launchSubmission() {
         optionalExpressionField="\"expression\":\"${expression}\","
     fi
 
-    submissionId=$(
+    submissionDetails=$(
         curl \
             -X POST \
             "https://api.firecloud.org/api/workspaces/${namespace}/${name}/submissions" \
@@ -105,9 +105,9 @@ launchSubmission() {
                 \"useCallCache\":${useCallCache}
             }
             " \
-            --compressed \
-        | jq -r '.submissionId'
-    )
+            --compressed)
+    echo "Working with submission details: ${submissionDetails}"
+    submissionId=$(echo "${submissionDetails}" | jq -r '.submissionId')
     echo "${submissionId}"
 }
 

--- a/automation/prod-workflow-inc.sh
+++ b/automation/prod-workflow-inc.sh
@@ -18,7 +18,6 @@ checkToken () {
             "https://api.firecloud.org/api/refresh-token-status" 2>&1 \
         | grep '"requiresRefresh": true'
     then
-        echo "$1 needs its refresh token refreshed"
         NEED_TOKEN=true
         export NEED_TOKEN
     fi
@@ -117,9 +116,7 @@ launchSubmission() {
             }
             " \
             --compressed)
-    echo "Working with submission details: ${submissionDetails}"
-    submissionId=$(echo "${submissionDetails}" | jq -r '.submissionId')
-    echo "${submissionId}"
+    submissionId=$(jq -r '.submissionId' <<< "${submissionDetails}")
 }
 
 monitorSubmission() {
@@ -136,10 +133,8 @@ monitorSubmission() {
             --header "Authorization: Bearer ${ACCESS_TOKEN}" \
             "https://api.firecloud.org/api/workspaces/$namespace/$name/submissions/$submissionId")
 
-    echo "Got submission details: ${submissionDetails}"
-
-    submissionStatus=$(echo "${submissionDetails}" | jq -r '.status')
-    workflowsStatus=$(echo "${submissionDetails}" | jq -r '.workflows[] | .status')
+    submissionStatus=$(jq -r '.status' <<< "${submissionDetails}")
+    workflowsStatus=$(jq -r '.workflows[] | .status' <<< "${submissionDetails}")
 
 
     export submissionStatus

--- a/automation/prod-workflow-inc.sh
+++ b/automation/prod-workflow-inc.sh
@@ -33,7 +33,7 @@ getAccessToken() {
     NEED_TOKEN=true
   fi
 
-  if [ "${NEED_TOKEN}" = "true"]
+  if [ "${NEED_TOKEN}" = "true" ]
   then
     ACCESS_TOKEN=$(
       docker \

--- a/automation/prod-workflow-inc.sh
+++ b/automation/prod-workflow-inc.sh
@@ -27,18 +27,29 @@ checkToken () {
 getAccessToken() {
   user=$1
 
-  [ "${ACCESS_TOKEN_USER}" = "${user}" -a -n "${ACCESS_TOKEN}" ] || ACCESS_TOKEN=$(
-    docker \
+  if [ "${ACCESS_TOKEN_USER}" = "${user}" -a -n "${ACCESS_TOKEN}" ]
+  then
+    checkToken "$user"
+  else
+    NEED_TOKEN=true
+  fi
+
+  if [ "${NEED_TOKEN}" = "true"]
+  then
+    ACCESS_TOKEN=$(
+      docker \
         run \
         --rm \
         -v "${WORKING_DIR}:/app/populate" \
         -w /app/populate \
         broadinstitute/dsp-toolbox \
         python get_bearer_token.py "${user}" "${JSON_CREDS}"
-  )
+    )
+  fi
 
   export ACCESS_TOKEN
   export ACCESS_TOKEN_USER="${user}"
+  export NEED_TOKEN=false
 }
 
 launchSubmission() {

--- a/automation/prod-workflow-inc.sh
+++ b/automation/prod-workflow-inc.sh
@@ -16,7 +16,7 @@ checkToken () {
             --header "Accept: application/json" \
             --header "Authorization: Bearer ${ACCESS_TOKEN}" \
             "https://api.firecloud.org/api/refresh-token-status" 2>&1 \
-        | grep '"requiresRefresh": true'
+        | grep '"requiresRefresh": true\|error: 401'
     then
         NEED_TOKEN=true
         export NEED_TOKEN

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -23,8 +23,9 @@ checkToken () {
 
 getAccessToken() {
   user=$1
+  timestampNow=$(date '+%s')
 
-  if [ "${ACCESS_TOKEN_USER}" = "${user}" -a -n "${ACCESS_TOKEN}" ]
+  if [ "${ACCESS_TOKEN_USER}" = "${user}" -a $(( $timestampNow - ${ACCESS_TOKEN_TIMESTAMP:-0} )) -lt 1800 -a -n "${ACCESS_TOKEN}" ]
   then
     checkToken "$user"
   else
@@ -45,6 +46,7 @@ getAccessToken() {
   fi
 
   export ACCESS_TOKEN
+  export ACCESS_TOKEN_TIMESTAMP="${timestampNow}"
   export ACCESS_TOKEN_USER="${user}"
   export NEED_TOKEN=false
 }

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -44,7 +44,7 @@ getAccessToken() {
     )
   fi
 
-  export ACCESS_TOKEN
+  export ACCESS_TOKEN="${ACCESS_TOKEN}"
   export ACCESS_TOKEN_USER="${user}"
   export NEED_TOKEN=false
 }

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -20,24 +20,34 @@ checkToken () {
         NEED_TOKEN=true
         export NEED_TOKEN
     fi
-
 }
 
 getAccessToken() {
   user=$1
 
-  [ "${ACCESS_TOKEN_USER}" = "${user}" -a -n "${ACCESS_TOKEN}" ] || ACCESS_TOKEN=$(
-    docker \
+  if [ "${ACCESS_TOKEN_USER}" = "${user}" -a -n "${ACCESS_TOKEN}" ]
+  then
+    checkToken "$user"
+  else
+    NEED_TOKEN=true
+  fi
+
+  if [ "${NEED_TOKEN}" = "true"]
+  then
+    ACCESS_TOKEN=$(
+      docker \
         run \
         --rm \
         -v "${WORKING_DIR}:/app/populate" \
         -w /app/populate \
         broadinstitute/dsp-toolbox \
         python get_bearer_token.py "${user}" "${JSON_CREDS}"
-  )
+    )
+  fi
 
   export ACCESS_TOKEN
   export ACCESS_TOKEN_USER="${user}"
+  export NEED_TOKEN=false
 }
 
 callbackToNIH() {

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -31,7 +31,7 @@ getAccessToken() {
     NEED_TOKEN=true
   fi
 
-  if [ "${NEED_TOKEN}" = "true"]
+  if [ "${NEED_TOKEN}" = "true" ]
   then
     ACCESS_TOKEN=$(
       docker \
@@ -44,7 +44,7 @@ getAccessToken() {
     )
   fi
 
-  export ACCESS_TOKEN="${ACCESS_TOKEN}"
+  export ACCESS_TOKEN
   export ACCESS_TOKEN_USER="${user}"
   export NEED_TOKEN=false
 }

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -14,7 +14,7 @@ checkToken () {
             --header "Accept: application/json" \
             --header "Authorization: Bearer ${ACCESS_TOKEN}" \
             "https://firecloud-orchestration.dsde-${ENV}.broadinstitute.org/api/refresh-token-status" 2>&1 \
-        | grep '"requiresRefresh": true'
+        | grep '"requiresRefresh": true\|error: 401'
     then
         NEED_TOKEN=true
         export NEED_TOKEN
@@ -23,9 +23,8 @@ checkToken () {
 
 getAccessToken() {
   user=$1
-  timestampNow=$(date '+%s')
 
-  if [ "${ACCESS_TOKEN_USER}" = "${user}" -a $(( $timestampNow - ${ACCESS_TOKEN_TIMESTAMP:-0} )) -lt 1800 -a -n "${ACCESS_TOKEN}" ]
+  if [ "${ACCESS_TOKEN_USER}" = "${user}" -a -n "${ACCESS_TOKEN}" ]
   then
     checkToken "$user"
   else
@@ -46,7 +45,6 @@ getAccessToken() {
   fi
 
   export ACCESS_TOKEN
-  export ACCESS_TOKEN_TIMESTAMP="${timestampNow}"
   export ACCESS_TOKEN_USER="${user}"
   export NEED_TOKEN=false
 }


### PR DESCRIPTION
Makes two improvements to the Cromwell CI scripts: 

- Added resilience should result in not having to re-fetch tokens every time one is needed. 
- When we fetch submission details, we now long what came back from curl so that we can debug it later if necessary.

Currently manually testing as: https://fcprod-jenkins.dsp-techops.broadinstitute.org/job/Complex-Workflow-testV2-against-prod/6601/