### PR TITLE
30m token timeout and more logging in 35k scatter test [BW-762]

### DIFF
--- a/automation/prod-workflow-inc.sh
+++ b/automation/prod-workflow-inc.sh
@@ -25,8 +25,11 @@ checkToken () {
             "https://api.firecloud.org/api/refresh-token-status" 2>&1 \
         | grep '"requiresRefresh": true\|error: 401'
     then
-        NEED_TOKEN=true
-        export NEED_TOKEN
+        export NEED_TOKEN=true
+    else if [ "$(( $(date +%s) - ${TOKEN_CREATION_TIME-0} ))" -gt "1800" ]
+        export NEED_TOKEN=true
+    else
+        export NEED_TOKEN=false
     fi
 }
 
@@ -57,6 +60,7 @@ getAccessToken() {
 
   export ACCESS_TOKEN
   export ACCESS_TOKEN_USER="${user}"
+  export TOKEN_CREATION_TIME=$(date +%s)
   export NEED_TOKEN=false
 }
 

--- a/automation/prod-workflow-inc.sh
+++ b/automation/prod-workflow-inc.sh
@@ -25,11 +25,8 @@ checkToken () {
             "https://api.firecloud.org/api/refresh-token-status" 2>&1 \
         | grep '"requiresRefresh": true\|error: 401'
     then
-        export NEED_TOKEN=true
-    else if [ "$(( $(date +%s) - ${TOKEN_CREATION_TIME-0} ))" -gt "1800" ]
-        export NEED_TOKEN=true
-    else
-        export NEED_TOKEN=false
+        NEED_TOKEN=true
+        export NEED_TOKEN
     fi
 }
 
@@ -60,7 +57,6 @@ getAccessToken() {
 
   export ACCESS_TOKEN
   export ACCESS_TOKEN_USER="${user}"
-  export TOKEN_CREATION_TIME=$(date +%s)
   export NEED_TOKEN=false
 }
 

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -27,7 +27,7 @@ checkToken () {
     if [[ "${tokenStatus}" =~ '"requiresRefresh":true' ]] || [[ ${tokenStatus} =~ "401 Unauthorized" ]]
     then
         export NEED_TOKEN=true
-    else if [ "$(( $(date +%s) - ${TOKEN_CREATION_TIME-0} ))" -gt "1800" ]
+    elif [ "$(( $(date +%s) - ${TOKEN_CREATION_TIME-0} ))" -gt "1800" ]
         export NEED_TOKEN=true
     else
         export NEED_TOKEN=false

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -48,8 +48,8 @@ getAccessToken() {
     NEED_TOKEN=true
   fi
 
-  while [ "${NEED_TOKEN}" = "true" ]
-  do
+  if [ "${NEED_TOKEN}" = "true" ]
+  then
     printf "\nRetrieving new ACCESS_TOKEN for user '%s'" "${user}"
     ACCESS_TOKEN=$(
       docker \
@@ -66,7 +66,7 @@ getAccessToken() {
     TOKEN_CREATION_TIME=$(date +%s)
     export TOKEN_CREATION_TIME
     checkToken "${user}"
-  done
+  fi
 }
 
 callbackToNIH() {

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -241,34 +241,16 @@ monitorSubmission() {
 
     printf "\nFetching status for submission ID '%s':" "${submissionId}"
 
-    submissionStatus=$(
+    submissionDetails=$(
         curl \
             -X GET \
             --header 'Accept: application/json' \
             --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-            "https://firecloud-orchestration.dsde-${ENV}.broadinstitute.org/api/workspaces/${namespace}/${name}/submissions/${submissionId}" \
-        | jq -r '.status'
-    )
-    workflowsStatus=$(
-        curl \
-            -X GET \
-            --header 'Accept: application/json' \
-            --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-            "https://firecloud-orchestration.dsde-${ENV}.broadinstitute.org/api/workspaces/${namespace}/${name}/submissions/${submissionId}" \
-         | jq -r '.workflows[] | .status'
-    )
-    workflowFailures=$(
-        curl \
-            -X GET \
-            --header 'Accept: application/json' \
-            --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-            "https://firecloud-orchestration.dsde-${ENV}.broadinstitute.org/api/workspaces/${namespace}/${name}/submissions/${submissionId}" \
-         | jq -r '[.workflows[] | select(.status == "Failed")] | length'
-    )
+            "https://firecloud-orchestration.dsde-${ENV}.broadinstitute.org/api/workspaces/${namespace}/${name}/submissions/${submissionId}")
 
-    export submissionStatus
-    export workflowsStatus
-    export workflowFailures
+    export submissionStatus=$(echo "$submissionDetails" | jq -r '.status')
+    export workflowsStatus=$(echo "$submissionDetails" | jq -r '.workflows[] | .status')
+    export workflowFailures=$(echo "$submissionDetails" | jq -r '[.workflows[] | select(.status == "Failed")] | length')
 }
 
 waitForSubmissionAndWorkflowStatus() {

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -28,6 +28,7 @@ checkToken () {
     then
         export NEED_TOKEN=true
     elif [ "$(( $(date +%s) - ${TOKEN_CREATION_TIME-0} ))" -gt "1800" ]
+    then
         echo "Token is over 30m old, so we need a new one"
         export NEED_TOKEN=true
     else

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -28,6 +28,7 @@ checkToken () {
     then
         export NEED_TOKEN=true
     elif [ "$(( $(date +%s) - ${TOKEN_CREATION_TIME-0} ))" -gt "1800" ]
+        echo "Token is over 30m old, so we need a new one"
         export NEED_TOKEN=true
     else
         export NEED_TOKEN=false

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -65,7 +65,7 @@ getAccessToken() {
     export ACCESS_TOKEN_USER
     TOKEN_CREATION_TIME=$(date +%s)
     export TOKEN_CREATION_TIME
-    checkToken
+    checkToken "${user}"
   done
 }
 


### PR DESCRIPTION
Note: Saloni mentioned problems in the following tests by switching to a "fetch submission details once" approach" the last time, but the benefits of "fetch once" are huge:

- The details are logged, so it's easier to debug what's going on
- The failures often happen on the second or third attempt to access the APIs, perhaps due to race conditions when the liveness check being several seconds or minutes behind the actual request.

Therefore, I am bringing it back, but:
- With a slightly different implementation
- In only `submission-perf-inc.sh`
- With manual testing of https://fc-jenkins.dsp-techops.broadinstitute.org/job/PerformanceTest-against-Alpha/ and https://fc-jenkins.dsp-techops.broadinstitute.org/job/alpha-impossible-to-read-archived-metadata-from-within-workflow-check/ against the branch as part of the testing for this change.