### PR TITLE
get ToS text from Sam [AS-918]

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This can take around 40 seconds to completely start. When ready, it will display
 Prompt will show when figwheel connects to your application
 ```
 
-To connect, load [`http://local.broadinstitute.org`](http://local.broadinstitute.org) in your browser (Chrome is strongly recommended for development). The prompt should appear less than ten seconds after you reload the page. If it is not connecting, make sure to check the JavaScript console for error messages.
+To connect, load ~~[`http://local.broadinstitute.org`](http://local.broadinstitute.org)~~ [`http://localhost:3449`](http://localhost:3449) in your browser (Chrome is strongly recommended for development). The prompt should appear less than ten seconds after you reload the page. If it is not connecting, make sure to check the JavaScript console for error messages.
 
 ### Building
 

--- a/src/cljs/main/broadfcui/auth.cljs
+++ b/src/cljs/main/broadfcui/auth.cljs
@@ -302,7 +302,12 @@
             (do
               (endpoints/tos-get-text
                 (fn [{:keys [success? status-code raw-response]}]
-                  (swap! state assoc :tos raw-response))) ;; TODO: probably need more elegant handling than raw-response
+                    (swap! state assoc :tos
+                      (if success?
+                        raw-response
+                        (str "Could not load Terms of Service; please read it at "
+                           (str (config/terra-base-url) "/#terms-of-service")
+                           ".")))))
               (case status-code
                 ;; 403 means the user declined the TOS (or has invalid token? Need to distinguish)
                 403 (swap! state assoc :error :declined)

--- a/src/cljs/main/broadfcui/auth.cljs
+++ b/src/cljs/main/broadfcui/auth.cljs
@@ -300,7 +300,9 @@
           (if success?
             (on-success)
             (do
-              (ajax/get-google-bucket-file "tos" #(swap! state assoc :tos (% (-> (config/tos-version) str keyword))))
+              (endpoints/tos-get-text
+                (fn [{:keys [success? status-code raw-response]}]
+                  (swap! state assoc :tos raw-response))) ;; TODO: probably need more elegant handling than raw-response
               (case status-code
                 ;; 403 means the user declined the TOS (or has invalid token? Need to distinguish)
                 403 (swap! state assoc :error :declined)

--- a/src/cljs/main/broadfcui/auth.cljs
+++ b/src/cljs/main/broadfcui/auth.cljs
@@ -278,7 +278,7 @@
                                         [:span {}
                                          "Loading Terms of Service; also available "
                                          [:a {:target "_blank"
-                                              :href "http://gatkforums.broadinstitute.org/firecloud/discussion/6819/firecloud-terms-of-service#latest"}
+                                              :href (str (config/terra-base-url) "/#terms-of-service")}
                                          "here"] "."]))
                                     [:div {:style {:display "flex" :width 200 :justifyContent "space-evenly" :marginTop "1rem"}}
                                      [buttons/Button {:text "Accept" :onClick #(endpoints/tos-set-status true update-status)}]]]]

--- a/src/cljs/main/broadfcui/endpoints.cljs
+++ b/src/cljs/main/broadfcui/endpoints.cljs
@@ -564,10 +564,9 @@
   {:path "/profile/importstatus"
    :method :get})
 
-;; TODO: change to actual url, e.g. /register/tos, once that is available
 (defn tos-get-text [on-done]
   (ajax/call-sam
-   (str "/version")
+   (str "/tos/text")
    {:on-done on-done}
    :service-prefix ""))
 

--- a/src/cljs/main/broadfcui/endpoints.cljs
+++ b/src/cljs/main/broadfcui/endpoints.cljs
@@ -564,6 +564,12 @@
   {:path "/profile/importstatus"
    :method :get})
 
+;; TODO: change to actual url, e.g. /register/tos, once that is available
+(defn tos-get-text [on-done]
+  (ajax/call-sam
+   (str "/version")
+   {:on-done on-done}
+   :service-prefix ""))
 
 (defn tos-get-status [on-done]
   (ajax/call-tos


### PR DESCRIPTION
AS-918

Grabs ToS text from Sam, instead of the firecloud-alerts bucket.

running in my local env, I can see it working:

![Screen Shot 2021-11-18 at 8 53 05 AM](https://user-images.githubusercontent.com/6041577/142428445-d38d75cc-7834-4e4b-be50-823d48b63aa7.png)


