### PR TITLE
Fix bad test: BW-1159

### DIFF
--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -174,7 +174,7 @@ findSubmissionID() {
     getAccessToken "$user"
 
     # The selector filter is appended to if namespace/name are applied. Otherwise, the base case is to have no filters and just find the most recent submission ID that exists.
-    selectorString="true" .
+    selectorString="true"
     if [[ -n "$methodConfigurationNamespace" && -n "$methodConfigurationName" ]]
         then
             printf "\nFetching last submission ID for workspace '%s' in namespace '%s':" "${name}" "${namespace}"

--- a/automation/submission-perf-inc.sh
+++ b/automation/submission-perf-inc.sh
@@ -173,7 +173,8 @@ findSubmissionID() {
 
     getAccessToken "$user"
 
-    selectorString=".status == (\"Submitted\")"
+    # The selector filter is appended to if namespace/name are applied. Otherwise, the base case is to have no filters and just find the most recent submission ID that exists.
+    selectorString="true" .
     if [[ -n "$methodConfigurationNamespace" && -n "$methodConfigurationName" ]]
         then
             printf "\nFetching last submission ID for workspace '%s' in namespace '%s':" "${name}" "${namespace}"


### PR DESCRIPTION
Fix a test case that only succeeded if its submission was still in the `Submitted` state after one minute. Presumably improved submission rate has rendered that no-longer-true (the submission is now `Done` more often than not, in recent history)