### PR TITLE
[DDO-2912] Migrate Firecloud UI configs out of firecloud-develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Choose `File -> New -> Project from Existing Sources...` and select the base `fi
 
 FireCloud is currently supported within Broad's engineering environment:
 
-https://github.com/broadinstitute/firecloud-develop
+https://github.com/broadinstitute/terra-helmfile
 
 Support for running FireCloud outside of the Broad is planned.
 
@@ -33,7 +33,10 @@ Support for running FireCloud outside of the Broad is planned.
 
 ### Development Stack Setup
 
-1. Make sure you've run the `render-configs.sh` script in the `develop` branch of the `firecloud-develop` repo to render the config files and run script.
+1. Render configuration files by running:
+```
+./local-dev/bin/render
+```
 2. Be sure you've added local.broadinstitute.org to your `/etc/hosts`:
 
 ```bash

--- a/local-dev/bin/render
+++ b/local-dev/bin/render
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eo pipefail
+
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+
+IMAGE_NAME="${IMAGE_NAME:-us-central1-docker.pkg.dev/dsp-artifact-registry/firecloud-develop-shim/firecloud-develop-shim}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+
+VAULT_TOKEN=$( cat ~/.vault-token )
+
+docker run --pull always \
+  -e VAULT_TOKEN="${VAULT_TOKEN}" \
+  -v "${REPO_ROOT}:/code" \
+  --rm -it "${IMAGE}" \
+  --secrets /code/local-dev/secrets.yaml \
+  --templates /code/local-dev/templates \
+  --output-dir /code/config
+
+cat <<EOF
+
+Don't forget to add the local.broadinstitute.org alias to your hosts file!
+
+$ sudo sh -c "echo '127.0.0.1       local.broadinstitute.org' >> /etc/hosts"
+
+EOF

--- a/local-dev/secrets.yaml
+++ b/local-dev/secrets.yaml
@@ -1,0 +1,8 @@
+vault:
+  # local.broadinstitute.org cert & key - used by docker-compose.yaml
+  - path: secret/dsde/firecloud/local/common/server.key
+    key: value
+    file: server.key
+  - path: secret/dsde/firecloud/local/common/server.crt
+    key: value
+    file: server.crt

--- a/local-dev/templates/config.json.ctmpl
+++ b/local-dev/templates/config.json.ctmpl
@@ -1,0 +1,27 @@
+{{- $refreshTokenOAuthCredential := (secret "secret/dsde/firecloud/dev/common/refresh-token-oauth-credential.json").Data -}}
+{
+  "apiUrlRoot": "http://localhost:8080",
+  "leonardoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",
+  "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
+  "bondUrl": "https://broad-bond-dev.appspot.com",
+  "marthaFileSummaryUrl": "https://us-central1-broad-dsde-dev.cloudfunctions.net/fileSummaryV1",
+  "marthaUrl": "https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v2",
+  "terraBaseUrl": "https://bvdp-saturn-dev.appspot.com",
+  "terraRedirectsEnabled": true,
+  "googleClientId": "{{ $refreshTokenOAuthCredential.web.client_id }}",
+  "isDebug": true,
+  "shibbolethUrlRoot": "http://mock-nih.dev.test.firecloud.org",
+  "tcgaNamespace": "broad-firecloud-tcga-dev",
+  "workflowCountWarningThreshold": 100,
+  "submissionStatusRefresh": 60000,
+  "userGuideUrl": "https://software.broadinstitute.org/firecloud/documentation/",
+  "userNotebooksGuideUrl": "https://software.broadinstitute.org/firecloud/documentation/quickstart?page=notebooks",
+  "forumUrl": "http://gatkforums.broadinstitute.org/firecloud",
+  "billingAccountGuideUrl": "http://gatkforums.broadinstitute.org/firecloud/discussion/9762/howto-set-up-a-google-billing-account-non-broad-users",
+  "billingProjectGuideUrl": "https://gatkforums.broadinstitute.org/firecloud/discussion/9763/howto-create-a-new-firecloud-billing-project",
+  "callCachingGuideUrl": "http://gatkforums.broadinstitute.org/firecloud/discussion/9313/call-caching",
+  "googleBucketUrl": "https://storage.googleapis.com/firecloud-alerts-dev/",
+  "dockstoreApiUrl": "https://staging.dockstore.org/api",
+  "dockstoreWebUrl": "https://staging.dockstore.org",
+  "metricsUrl": "https://terra-bard-dev.appspot.com"
+}

--- a/local-dev/templates/docker-compose.yaml
+++ b/local-dev/templates/docker-compose.yaml
@@ -1,0 +1,14 @@
+ui:
+  image: broadinstitute/firecloud-ui:dev
+  ports:
+    - "80:80"
+    - "443:443"
+  volumes:
+    - ./server.crt:/etc/ssl/certs/server.crt
+    - ./server.key:/etc/ssl/private/server.key
+    - .:/config:rw
+    - ../:/app:rw
+  environment:
+    LOG_LEVEL: debug
+    SERVER_NAME: local.broadinstitute.org
+    HTTPS_ONLY: "false"

--- a/local-dev/templates/docker-rsync-local-ui.sh
+++ b/local-dev/templates/docker-rsync-local-ui.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+set -x
+
+hash fswatch 2>/dev/null || {
+    echo >&2 "This script requires fswatch (https://github.com/emcrisostomo/fswatch), but it's not installed. On Darwin, just \"brew install fswatch\".  Aborting."; exit 1;
+}
+
+if [ -a ./.docker-rsync-local.pid ]; then
+    echo "Looks like clean-up wasn't completed, doing it now..."
+    docker rm -f ui-rsync-container
+    docker rm -f ui-mock-server
+    docker rm -f ui-clojure
+    docker rm -f ui-webpack
+    pkill -P $(< "./.docker-rsync-local.pid")
+    rm ./.docker-rsync-local.pid
+    rm ./.docker-rsync-local.log
+fi
+
+clean_up () {
+    echo
+    echo "Cleaning up after myself..."
+    docker rm -f ui-mock-server
+    docker rm -f ui-rsync-container
+    docker rm -f ui-webpack
+    pkill -P $$
+    rm ./.docker-rsync-local.pid
+    rm ./.docker-rsync-local.log
+}
+trap clean_up EXIT HUP INT QUIT PIPE TERM 0 20
+
+echo $$ > ./.docker-rsync-local.pid
+# Truncate the log (rather than delete) in case someone is tailing it.
+> .docker-rsync-local.log
+
+echo "Launching mock server..."
+
+DOCKERHOST=$(docker network inspect bridge -f='{{(index .IPAM.Config 0).Gateway}}')
+
+if [[ -z $DOCKERHOST ]]; then
+    echo "IPAM.Config.Gateway not found.  The Docker daemon may need a reload."
+    echo "See https://github.com/moby/moby/issues/26799 for details."
+    exit 2
+fi
+
+docker run -d \
+  --name ui-mock-server \
+  -p 8080:8080 \
+  --add-host local.broadinstitute.org:$DOCKERHOST \
+  rodolpheche/wiremock:2.13.0-alpine
+
+echo "Launching rsync container..."
+docker run -d \
+    --name ui-rsync-container \
+    -v ui-shared-source:/working \
+    -e DAEMON=docker \
+    tjamet/rsync
+
+sync_src () {
+    rsync --blocking-io -azlv --delete -e "docker exec -i" . ui-rsync-container:working \
+        --filter='+ /project.clj' \
+        --filter='+ /src/***' \
+        --filter='+ webpack.config.js' \
+        --filter='+ package.json' \
+        --filter='+ package-lock.json' \
+        --filter='- *' \
+        >> ./.docker-rsync-local.log
+}
+
+echo "Performing initial file sync..."
+sync_src; fswatch -o project.clj src/ | while read f; do sync_src; done &
+ENV="${ENV:-}"
+docker exec ui-rsync-container mkdir -p /working/resources/public
+if [[ "$ENV" = 'qa' ]]; then
+      docker cp config/config.json.qa ui-rsync-container:/working/resources/public/config.json
+else
+      docker cp config/config.json ui-rsync-container:/working/resources/public/config.json
+fi
+docker cp config/tcell.js ui-rsync-container:/working/resources/public/tcell.js
+
+echo "Standing up webpack watcher..."
+docker pull broadinstitute/clojure-node:latest
+docker run -d \
+      --name ui-webpack \
+      -w /work -v ui-shared-source:/work -v node-modules:/work/node_modules \
+      -e npm_config_unsafe_perm='true' \
+      broadinstitute/clojure-node \
+      bash -c 'npm install && npm run webpack -- --watch'
+
+echo "Configuring mock server..."
+LOCAL_ORCH="${LOCAL_ORCH:-}"
+FIAB="${FIAB:-}"
+if [[ "$LOCAL_ORCH" = 'true' ]]; then
+    echo "Running with local orch"
+    curl --data-binary @config/wiremock-proxy-local.json http://localhost:8080/__admin/mappings/new
+elif [[ "$FIAB" = 'true' ]]; then
+    if [[ "$ENV" = 'qa' ]]; then
+        echo "Running with qa FiaB orch"
+        curl --data-binary @config/wiremock-proxy-fiab-qa.json http://localhost:8080/__admin/mappings/new
+    else
+        echo "Running with dev FiaB orch"
+        curl --data-binary @config/wiremock-proxy-fiab-dev.json http://localhost:8080/__admin/mappings/new
+    fi
+else
+    echo "Running with dev orch"
+    curl --data-binary @config/wiremock-proxy-dev.json http://localhost:8080/__admin/mappings/new
+fi
+echo
+echo
+echo "Mock server is running. Mock requests like so:"
+echo
+echo "  ./scripts/addmockresponse.sh src/wiremock/billing-pending.json"
+echo
+echo
+
+start_server () {
+    # Starts figwheel so changes are immediately loaded into the running browser window and appear
+    # without requiring a page reload.
+
+    echo "Checking if port 80 is free..."
+    set +e
+    if docker run --rm -p 80:3449 broadinstitute/clojure-node true; then
+      PORT_80_FREE=true
+    else
+      PORT_80_FREE=false
+    fi
+    set -e
+
+    if "$PORT_80_FREE"; then
+      EXPOSED_PORTS=(-p 80:3449 -p 3449:3449)
+    else
+      EXPOSED_PORTS=(-p 3449:3449)
+    fi
+
+    echo "Launching Clojure docker container..."
+    docker run --rm -it \
+      --name ui-clojure \
+      -w /work -v ui-shared-source:/work -v jar-cache:/root/.m2 \
+      ${EXPOSED_PORTS[*]} \
+      broadinstitute/clojure-node \
+      bash -c 'sleep 1; rlwrap lein figwheel'
+}
+start_server

--- a/local-dev/templates/tcell.js.ctmpl
+++ b/local-dev/templates/tcell.js.ctmpl
@@ -1,0 +1,7 @@
+{{- $tcell := (secret "secret/dsde/firecloud/local/firecloudui/tcell" ).Data -}}
+var tcellScript = document.createElement('script');
+tcellScript.setAttribute('type', 'text/javascript');
+tcellScript.setAttribute('src', 'https://us.jsagent.tcell.insight.rapid7.com/tcellagent.min.js');
+tcellScript.setAttribute('tcellappid', '{{ $tcell.appid }}');
+tcellScript.setAttribute('tcellapikey', '{{ $tcell.apikey }}');
+document.head.appendChild(tcellScript);

--- a/local-dev/templates/wiremock-proxy-dev.json
+++ b/local-dev/templates/wiremock-proxy-dev.json
@@ -1,0 +1,9 @@
+{
+  "request": {
+    "method": "ANY",
+    "urlPattern": ".*"
+  },
+  "response": {
+    "proxyBaseUrl": "https://firecloud-orchestration.dsde-dev.broadinstitute.org"
+  }
+}

--- a/local-dev/templates/wiremock-proxy-fiab-dev.json
+++ b/local-dev/templates/wiremock-proxy-fiab-dev.json
@@ -1,0 +1,9 @@
+{
+  "request": {
+    "method": "ANY",
+    "urlPattern": ".*"
+  },
+  "response": {
+    "proxyBaseUrl": "https://firecloud-orchestration-fiab.dsde-dev.broadinstitute.org:23443"
+  }
+}

--- a/local-dev/templates/wiremock-proxy-fiab-qa.json
+++ b/local-dev/templates/wiremock-proxy-fiab-qa.json
@@ -1,0 +1,9 @@
+{
+  "request": {
+    "method": "ANY",
+    "urlPattern": ".*"
+  },
+  "response": {
+    "proxyBaseUrl": "https://firecloud-orchestration-fiab.dsde-qa.broadinstitute.org:23443"
+  }
+}

--- a/local-dev/templates/wiremock-proxy-local.json
+++ b/local-dev/templates/wiremock-proxy-local.json
@@ -1,0 +1,9 @@
+{
+  "request": {
+    "method": "ANY",
+    "urlPattern": ".*"
+  },
+  "response": {
+    "proxyBaseUrl": "https://local.broadinstitute.org:10443"
+  }
+}


### PR DESCRIPTION
The goal of this PR is to do **the minimal amount of work** to migrate the existing Firecloud UI local development configuration out of firecloud-develop.

Under the existing process, developers clone firecloud-develop and run `render-configs.sh`, which populates the `configs` subdirectory with configuration files and secrets, as well as a script called `docker-rsync-local-ui.sh`, which can be run to spin up a local Firecloud UI server inside a container.

This PR replaces the firecloud-develop step with a new helper script, `local-dev/bin/render`, that **generates the same set of files**. The [`render` tool](https://github.com/broadinstitute/firecloud-develop-shim) generates 3 types of configuration files, giving it approximate parity with firecloud-develop's `configure.rb`:
* secrets pulled from Vault (declared in `local-dev/secrets.yaml`)
* flat configuration files (checked in under `local-dev/templates` without a `.ctmpl`  extension)
* consul templates (checked in under `local-dev/templates` with a `.ctmpl` extension)

### Testing

I was not able to get Firecloud UI running locally! The docker-rsync-local-ui.sh script hangs after logging:
```
Launching Clojure docker container...
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```
I suspect it's because the existing Docker images do not support ARM. Hopefully someone on the Workflows team can help with testing.

### Modified files

A diff on the files generated by the old process and the new process showed the following delta:

#### config.json
```
Files config/config.json and config.from-fc-dev/config.json differ
diff -r -w -b -B config/config.json config.from-fc-dev/config.json
1a14,15
>
>
8a29,30
>
>
```
This difference is whitespace-only.

#### docker-compose.yaml
```
Files config/docker-compose.yaml and config.from-fc-dev/docker-compose.yaml differ
6a7
>     - ./ca-bundle.crt:/etc/ssl/certs/ca-bundle.crt
```

I removed the ca-bundle.crt file. It is no longer used in live environments, which have certs provisioned by cert manager, and is not necessary for the browser to trust the local.broadinstitute.org cert.

#### local.broadinstitute.org cert & key
```
Only in config: server.crt
Only in config: server.key
```
These files are the `local.broadinstitute.org` cert & key pair located at `secret/dsde/firecloud/local/common`. They were removed from firecloud-develop configs for by https://github.com/broadinstitute/firecloud-develop/pull/3326, which broke TLS for some services. This PR adds them back.

### Related

* https://github.com/broadinstitute/firecloud-develop/pull/3386 will be merged after this PR to prevent confusion (i.e. people updating old files that are no longer used)
-----
- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: If you changed a URL that is used elsewhere (e.g. in an email), comment about where it is used and ensure the dependent code is updated.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] **Submitter**: If you're adding new automated UI tests, review the test plan with QA
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Submitter**: Verify all tests go green, including CI tests and automated UI tests.
- [ ] **Submitter**: Squash commits and merge to develop. If adding test code, merge application code and test code at the same time.
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
